### PR TITLE
Fix shifting table rows when applying search filters in /groups

### DIFF
--- a/client/app/blueprints/public/static/main.css
+++ b/client/app/blueprints/public/static/main.css
@@ -9,3 +9,10 @@
 .corporate-logo {
     width: 25em;
 }
+
+/* CSS OVERRIDES */
+/* Prevent search ui from pushing table data off screen */
+/* when applying search filters in /groups              */
+div#grid_grid_searches.w2ui-grid-searches {
+    margin-right:0!important
+}


### PR DESCRIPTION
Added a CSS override specific to the w2grid ui element that leads to issue #47 when applying search filters.

### How to setup and perform the tests

![animation](https://i.imgur.com/0iMfQgA.gif)

1. Set up a bonsai instance based on this branch
2. Apply a search filter using the advanced search menu that results in at least one sample displayed
3. Ensure that the table rows are not shifted to the left and that the sample ids are not obscured