### PR TITLE
WIP - Build and publish docker images on push/pull to master

### DIFF
--- a/.github/workflows/ci-api.yml
+++ b/.github/workflows/ci-api.yml
@@ -1,4 +1,4 @@
-name: Bonsai Client CI
+name: Bonsai API CI
 
 on:
   push:
@@ -29,4 +29,4 @@ jobs:
           context: client
           file: ./Dockerfile
           push: true
-          tags: clinicalgenomicslund/bonsai_app:latest
+          tags: clinicalgenomicslund/bonsai_api:latest

--- a/.github/workflows/ci-api.yml
+++ b/.github/workflows/ci-api.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Build and push
         uses: docker/build-push-action@v5
         with:
-          context: client
+          context: server
           file: ./Dockerfile
           push: true
           tags: clinicalgenomicslund/bonsai_api:latest

--- a/.github/workflows/ci-api.yml
+++ b/.github/workflows/ci-api.yml
@@ -1,0 +1,32 @@
+name: Bonsai Client CI
+
+on:
+  push:
+    branches: [ "master" ]
+    paths:
+      - server/**
+  pull_request:
+    branches: [ "master" ]
+    paths:
+      - server/**
+      
+jobs:            
+  push_to_dockerhub:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v4
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Build and push
+        uses: docker/build-push-action@v5
+        with:
+          context: client
+          file: ./Dockerfile
+          push: true
+          tags: clinicalgenomicslund/bonsai_app:latest

--- a/.github/workflows/ci-client.yml
+++ b/.github/workflows/ci-client.yml
@@ -1,0 +1,32 @@
+name: Bonsai Client CI
+
+on:
+  push:
+    branches: 
+    paths:
+      - client/**
+  pull_request:
+    branches: [ "master" ]
+    paths:
+      - client/**
+      
+jobs:            
+  push_to_dockerhub:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v4
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Build and push
+        uses: docker/build-push-action@v5
+        with:
+          context: client
+          file: ./Dockerfile
+          push: true
+          tags: clinicalgenomicslund/bonsai_app:latest


### PR DESCRIPTION
## WIP

This update configures two Github Actions to build and push docker images for the api and client respectively. Both are triggered on pushes/PRs that contain any changes to the `server/` and `client/` directories (much in the same way tests are triggered for bjorn in the Clinical-Genomics-Lund/bnf-infrastructure repo )

For this to work the organization repo first needs to set up Github secrets that define a `DOCKERHUB_USERNAME` and `DOCKERHUB_TOKEN` with access to `clinicalgenomicslund`