### PR TITLE
Add kraken2 species prediction results to sample view and fix cmlst missing alleles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,11 @@
  - Find similar samples by calculating MinHash distance
  - Added async similarity searches and clustering
  - User can choose clustering method from the sample basket
+ - Added spp prediction result to sample view
 
 ### Fixed
+
+ - Fixed calculation of missing and novel cgmlst alleles
 
 ### Changed
 

--- a/frontend/app/blueprints/api/views.py
+++ b/frontend/app/blueprints/api/views.py
@@ -1,11 +1,11 @@
 """Declaration of flask api entrypoints"""
 import json
 
-from app.bonsai import (TokenObject, add_samples_to_basket,
-                        remove_samples_from_basket)
-from app.models import SampleBasketObject
 from flask import Blueprint, flash, jsonify, request, session
 from flask_login import current_user, login_required
+
+from app.bonsai import TokenObject, add_samples_to_basket, remove_samples_from_basket
+from app.models import SampleBasketObject
 
 api_bp = Blueprint("api", __name__, template_folder="templates", static_folder="static")
 

--- a/frontend/app/blueprints/cluster/views.py
+++ b/frontend/app/blueprints/cluster/views.py
@@ -4,11 +4,12 @@ import logging
 from enum import Enum
 from typing import Dict
 
-from app.bonsai import TokenObject, cluster_samples, get_samples_by_id
 from flask import Blueprint, flash, redirect, render_template, request, url_for
 from flask_login import current_user, login_required
 from pydantic import BaseModel
 from requests.exceptions import HTTPError
+
+from app.bonsai import TokenObject, cluster_samples, get_samples_by_id
 
 LOG = logging.getLogger(__name__)
 

--- a/frontend/app/blueprints/comparison/views.py
+++ b/frontend/app/blueprints/comparison/views.py
@@ -1,8 +1,9 @@
 """Views for comparing multiple samples."""
 
-from app.mimer import TokenObject
 from flask import Blueprint, redirect, render_template, session, url_for
 from flask_login import current_user, login_required
+
+from app.mimer import TokenObject
 
 comparison_bp = Blueprint(
     "comparison",

--- a/frontend/app/blueprints/groups/views.py
+++ b/frontend/app/blueprints/groups/views.py
@@ -1,13 +1,29 @@
 """Declaration of views for groups"""
 import json
 
-from app.bonsai import (TokenObject, create_group, delete_group, get_groups,
-                        get_samples, get_samples_by_id, get_samples_in_group,
-                        update_group)
-from app.models import PhenotypeType
-from flask import (Blueprint, current_app, flash, redirect, render_template,
-                   request, session, url_for)
+from flask import (
+    Blueprint,
+    current_app,
+    flash,
+    redirect,
+    render_template,
+    request,
+    session,
+    url_for,
+)
 from flask_login import current_user, login_required
+
+from app.bonsai import (
+    TokenObject,
+    create_group,
+    delete_group,
+    get_groups,
+    get_samples,
+    get_samples_by_id,
+    get_samples_in_group,
+    update_group,
+)
+from app.models import PhenotypeType
 
 groups_bp = Blueprint(
     "groups",

--- a/frontend/app/blueprints/login/views.py
+++ b/frontend/app/blueprints/login/views.py
@@ -1,10 +1,10 @@
+from flask import Blueprint, flash, redirect, render_template, request, session, url_for
+from flask_login import UserMixin, login_required, login_user, logout_user
+from requests.exceptions import HTTPError
+
 from app import __version__ as VERSION
 from app.bonsai import TokenObject, get_auth_token, get_current_user
 from app.extensions import login_manager
-from flask import (Blueprint, flash, redirect, render_template, request,
-                   session, url_for)
-from flask_login import UserMixin, login_required, login_user, logout_user
-from requests.exceptions import HTTPError
 
 login_bp = Blueprint(
     "login",

--- a/frontend/app/blueprints/public/views.py
+++ b/frontend/app/blueprints/public/views.py
@@ -1,6 +1,6 @@
+from flask import Blueprint, current_app, render_template, request, send_from_directory
+
 from app import __version__ as VERSION
-from flask import (Blueprint, current_app, render_template, request,
-                   send_from_directory)
 
 public_bp = Blueprint(
     "public",

--- a/frontend/app/blueprints/sample/templates/cards.html
+++ b/frontend/app/blueprints/sample/templates/cards.html
@@ -194,3 +194,29 @@
     </div>
 </div>
 {% endmacro %}
+
+{% macro species_prediction_card(predictions) %}
+<div class="card">
+    <div class="card-header">Species prediction</div>
+    <div class="card-body">
+        <table class="table table-sm">
+            <thead>
+                <th>Specie</th>
+                <th>Fraction of reads</th>
+                <th>N reads</th>
+            </thead>
+            <tbody>
+                {% for pred in predictions %}
+                    <tr class="{% if predictions | length > 1 and loop.index == 1 %}table-success{% endif %}">
+                        <td> <a class="text-decoration-underline text-dark fst-italic" 
+                               href="https://www.ncbi.nlm.nih.gov/datasets/taxonomy/{{pred.taxonomy_id}}/" 
+                               target="_blank">{{pred.scientific_name}}</a></td>
+                        <td>{{ (pred.fraction_total_reads * 100) | fmt_number(2) }}%</td>
+                        <td>{{ pred.kraken_assigned_reads | fmt_to_human_readable }}</td>
+                    </tr>
+                {% endfor %}
+            </tbody>
+        </table>
+    </div>
+</div>
+{% endmacro %}

--- a/frontend/app/blueprints/sample/templates/sample.html
+++ b/frontend/app/blueprints/sample/templates/sample.html
@@ -1,6 +1,6 @@
 {% extends "layout.html" %}
 {% from "sidebar.html" import sidebar, table_of_content %}
-{% from "cards.html" import resistance_summary_card, resistance_table_card, virulence_card %}
+{% from "cards.html" import resistance_summary_card, resistance_table_card, virulence_card, species_prediction_card %}
 
 {% block css %}
 {{ super() }}
@@ -312,6 +312,11 @@
                 </div>
                 <div class="col-sm-12 col-md-10 order-md-0 mt-2">
                     {{ sample_header(sample) }}
+                </div>
+            </div>
+            <div class="row">
+                <div class="col-sm-12 col-md-auto">
+                    {{ species_prediction_card(sample.species_prediction) }}
                 </div>
             </div>
             <div class="col col-sm-12 col-md-10 order-md-2">

--- a/frontend/app/blueprints/sample/templates/sample.html
+++ b/frontend/app/blueprints/sample/templates/sample.html
@@ -245,7 +245,7 @@
             </tr>
             <tr>
                 <th scope="row">N Missing Alleles</th>
-                <td>{{ result.result.alleles | cgmlst_count_missing }}</td>
+                <td>{{ result.result.alleles | cgmlst_count_missing - result.result.n_novel }}</td>
             </tr>
         </table>
     </div>

--- a/frontend/app/blueprints/sample/views.py
+++ b/frontend/app/blueprints/sample/views.py
@@ -1,18 +1,30 @@
 """Declaration of views for samples"""
 from itertools import chain, groupby
 
-from app.bonsai import (TokenObject, cgmlst_cluster_samples,
-                        find_and_cluster_similar_samples,
-                        find_samples_similar_to_reference, get_group_by_id,
-                        get_sample_by_id, post_comment_to_sample,
-                        remove_comment_from_sample,
-                        update_sample_qc_classification)
-from app.models import (NT_TO_AA, BadSampleQualityAction, ElementType,
-                        PredictionSoftware)
-from flask import (Blueprint, current_app, flash, redirect, render_template,
-                   request, url_for)
+from flask import (
+    Blueprint,
+    current_app,
+    flash,
+    redirect,
+    render_template,
+    request,
+    url_for,
+)
 from flask_login import current_user, login_required
 from requests.exceptions import HTTPError
+
+from app.bonsai import (
+    TokenObject,
+    cgmlst_cluster_samples,
+    find_and_cluster_similar_samples,
+    find_samples_similar_to_reference,
+    get_group_by_id,
+    get_sample_by_id,
+    post_comment_to_sample,
+    remove_comment_from_sample,
+    update_sample_qc_classification,
+)
+from app.models import NT_TO_AA, BadSampleQualityAction, ElementType, PredictionSoftware
 
 samples_bp = Blueprint(
     "samples",

--- a/frontend/app/custom_filters.py
+++ b/frontend/app/custom_filters.py
@@ -84,9 +84,11 @@ def _jinja2_filter_datetime(date, fmt=None):
 
 
 def cgmlst_count_called(alleles: Dict[str, int | str | None]) -> int:
-    """Return the number of called allleles
+    """Return the number of called alleles
+    
+    Values other than integers are treated as failed calls and are not counted.
 
-    :param alleles: called allleles
+    :param alleles: called alleles
     :type alleles: Dict[str, int | str | None]
     :return: The number of called alleles
     :rtype: int

--- a/frontend/app/custom_filters.py
+++ b/frontend/app/custom_filters.py
@@ -1,4 +1,5 @@
 """Custom jinja3 template tests."""
+import math
 from collections import defaultdict
 from itertools import chain
 
@@ -202,6 +203,39 @@ def has_same_analysis_profile(samples):
     return len(set(profiles)) == 1
 
 
+def human_readable_large_numbers(number: float, decimals: int = 2) -> str:
+    """Large number to human readable version.
+
+    E.g 2345000 -> 2.35 Mega
+
+    :param number: large number to convert
+    :type number: float
+    :param decimals: number of decimals to round number to, defaults to 2
+    :type decimals: int, optional
+    :return: rounded human readable number with SI prefix
+    :rtype: str
+    """
+    power = math.floor(math.log10(number))
+    # source: https://sv.wikipedia.org/wiki/SI-prefix
+    SI_PREFIXES = {
+        1: "Kilo",
+        2: "Mega",
+        3: "Giga",
+        4: "Tera",
+        5: "Peta",
+        6: "Exa",
+        7: "Zetta",
+        8: "Yotta",
+        9: "Ronna",
+        10: "Quetta",
+    }
+    order = power // 3
+    # long number to rounded short number, 1230 -> 1.23 Kilo
+    short_number = round(number / math.pow(10, 3 * order), decimals)
+    prefix = SI_PREFIXES[order]
+    return f"{short_number} {prefix[0]}"
+
+
 TESTS = {
     "list": is_list,
 }
@@ -220,4 +254,5 @@ FILTERS = {
     "fmt_null_values": fmt_null_values,
     "has_same_analysis_profile": has_same_analysis_profile,
     "get_pvl_tag": get_pvl_tag,
+    "fmt_to_human_readable": human_readable_large_numbers,
 }

--- a/frontend/app/custom_filters.py
+++ b/frontend/app/custom_filters.py
@@ -1,13 +1,17 @@
 """Custom jinja3 template tests."""
 import math
+import logging
 from collections import defaultdict
 from itertools import chain
+from typing import Dict
 
 from dateutil.parser import parse
 from jsonpath2.path import Path as JsonPath
 
 from .config import ANTIBIOTIC_CLASSES
 from .models import TAG_LIST, Severity, Tag, TagType, VirulenceTag
+
+LOG = logging.getLogger(__name__)
 
 
 def is_list(value) -> bool:
@@ -79,12 +83,28 @@ def _jinja2_filter_datetime(date, fmt=None):
     return native.strftime(format)
 
 
-def cgmlst_count_called(alleles):
-    return sum(1 for allele in alleles.values() if allele is not None)
+def cgmlst_count_called(alleles: Dict[str, int | str | None]) -> int:
+    """Return the number of called allleles
+
+    :param alleles: called allleles
+    :type alleles: Dict[str, int | str | None]
+    :return: The number of called alleles
+    :rtype: int
+    """    
+    return sum(1 for allele in alleles.values() if isinstance(allele, int))
 
 
-def cgmlst_count_missing(alleles):
-    return sum(1 for allele in alleles.values() if allele is None)
+def cgmlst_count_missing(alleles: Dict[str, int | str | None]) -> int:
+    """Count the number of missing alleles.
+     
+    Strings and null values are treated as failed calls.
+
+    :param alleles: called alleles
+    :type alleles: Dict[str, int  |  str  |  None]
+    :return: Number of missing alleles
+    :rtype: int
+    """    
+    return sum(1 for allele in alleles.values() if isinstance(allele, str) or allele is None)
 
 
 def nt_to_aa(nt_seq):

--- a/frontend/app/custom_filters.py
+++ b/frontend/app/custom_filters.py
@@ -254,8 +254,12 @@ def human_readable_large_numbers(number: float, decimals: int = 2) -> str:
     order = power // 3
     # long number to rounded short number, 1230 -> 1.23 Kilo
     short_number = round(number / math.pow(10, 3 * order), decimals)
-    prefix = SI_PREFIXES[order]
-    return f"{short_number} {prefix[0]}"
+    prefix = SI_PREFIXES.get(order)
+    if prefix:
+        res = f"{short_number} {prefix}"
+    else: 
+        res = str(short_number)
+    return res
 
 
 TESTS = {

--- a/frontend/app/custom_filters.py
+++ b/frontend/app/custom_filters.py
@@ -1,6 +1,6 @@
 """Custom jinja3 template tests."""
-import math
 import logging
+import math
 from collections import defaultdict
 from itertools import chain
 from typing import Dict
@@ -90,21 +90,23 @@ def cgmlst_count_called(alleles: Dict[str, int | str | None]) -> int:
     :type alleles: Dict[str, int | str | None]
     :return: The number of called alleles
     :rtype: int
-    """    
+    """
     return sum(1 for allele in alleles.values() if isinstance(allele, int))
 
 
 def cgmlst_count_missing(alleles: Dict[str, int | str | None]) -> int:
     """Count the number of missing alleles.
-     
+
     Strings and null values are treated as failed calls.
 
     :param alleles: called alleles
     :type alleles: Dict[str, int  |  str  |  None]
     :return: Number of missing alleles
     :rtype: int
-    """    
-    return sum(1 for allele in alleles.values() if isinstance(allele, str) or allele is None)
+    """
+    return sum(
+        1 for allele in alleles.values() if isinstance(allele, str) or allele is None
+    )
 
 
 def nt_to_aa(nt_seq):


### PR DESCRIPTION
This PR adds a specie prediction card to the sample view in Bonsai frontend and fixes the calculation of the number of cgmlst alleles.

closes #101 #100 

### How to setup and perform the tests

1. step bonsai and load a sample to the database
2. goto the sample view

sample with one predicted spp, http://mtlucmds2.lund.skane.se:8812/samples/11MT0500255
sample with two predicted spp, http://mtlucmds2.lund.skane.se:8812/samples/11MT0500122

### Expected outcome 

- The species prediction result should be displayed and understandable. 
- The correct number of cgmlst alleles should be displayed.