### PR TITLE
Let users set QC status for multiple samples from /groups

### DIFF
--- a/api/app/models/qc.py
+++ b/api/app/models/qc.py
@@ -7,7 +7,7 @@ from .base import RWModel
 
 
 class SampleQcClassification(Enum):
-    """Actions that could be taken if a sample have low quality."""
+    """QC statuses."""
 
     # phenotype
     PASSED = "passed"

--- a/frontend/app/app.py
+++ b/frontend/app/app.py
@@ -24,6 +24,10 @@ def create_app():
     app.jinja_env.add_extension("jinja2.ext.do")
     app.jinja_env.globals.update(zip_longest=zip_longest)
 
+    # whitespace control:
+    app.jinja_env.trim_blocks = True
+    app.jinja_env.lstrip_blocks = True
+
     # configure pages etc
     register_blueprints(app)
     register_filters(app)

--- a/frontend/app/blueprints/groups/templates/groups.html
+++ b/frontend/app/blueprints/groups/templates/groups.html
@@ -133,8 +133,9 @@
             ],
             async onSelect(event) {
                 await event.complete
-                // enable add to basket button when some rows are selected
+                // enable add to basket + toggle qc buttons when user selects at least one row
                 document.getElementById("add-to-basket-btn").disabled = 1 > this.getSelection().length
+                document.getElementById("toggle-qc-btn").disabled = 1 > this.getSelection().length
                 // enable find simiar samples button when ONE row is selected
                 document.getElementById("select-similar-samples-btn").disabled = 1 !== this.getSelection().length
                 // update slected samples counter

--- a/frontend/app/blueprints/groups/templates/groups.html
+++ b/frontend/app/blueprints/groups/templates/groups.html
@@ -165,6 +165,11 @@
         grid.autoLoad = auto
         grid.skip(0)
     }
+
+    const selected_samples = {{selected_samples | tojson |safe }}
+    if (selected_samples.length > 0) {
+        window.action('select', selected_samples.map(sample => sample))
+    }
     grid.render()
     refreshGrid(true)
 </script>

--- a/frontend/app/blueprints/groups/templates/groups.html
+++ b/frontend/app/blueprints/groups/templates/groups.html
@@ -1,5 +1,5 @@
 {% extends "layout.html" %}
-{% from "shared.html" import search_similar_btn, search_similar_js, add_to_basket_btn, add_to_basket_js %}
+{% from "shared.html" import search_similar_btn, search_similar_js, add_to_basket_btn, add_to_basket_js, qc_bulk_toggle %}
 
 {% block css %}
 {{ super() }}
@@ -38,6 +38,7 @@
                         Create group
                     </a>
                 {% endif %}
+                {{ qc_bulk_toggle(['foo', 'bar'])}}
             </div>
         </nav>
         <div id="data-table"></div>

--- a/frontend/app/blueprints/groups/templates/groups.html
+++ b/frontend/app/blueprints/groups/templates/groups.html
@@ -38,7 +38,7 @@
                         Create group
                     </a>
                 {% endif %}
-                {{ qc_bulk_toggle(['foo', 'bar'])}}
+                {{ qc_bulk_toggle(bad_qc_actions)}}
             </div>
         </nav>
         <div id="data-table"></div>
@@ -175,7 +175,6 @@
     {{ add_to_basket_js() }}
     // template code for searching similar samples
     {{ search_similar_js() }}
-
 </script>
 {% endblock content %}
 

--- a/frontend/app/blueprints/groups/templates/shared.html
+++ b/frontend/app/blueprints/groups/templates/shared.html
@@ -202,7 +202,7 @@ document.getElementById("similar-samples-threshold").addEventListener("input", (
     </div>
     <script>
      // Add data from JS table to qc bulk edit form before submit
-     let qcForm = document.getElementById("qc-form-control");
+     const qcForm = document.getElementById("qc-form-control");
      qcForm.addEventListener("submit", (e) => {
          e.preventDefault();
          addSelectedSamplesToQcForm(qcForm)
@@ -217,7 +217,7 @@ document.getElementById("similar-samples-threshold").addEventListener("input", (
       */
      function addSelectedSamplesToQcForm(form) {
          // Retrieve selected samples from sessionStorage
-         var selectedSamples = window.getSelectedRows()
+         let selectedSamples = window.getSelectedRows()
 
          // Remove existing hidden inputs with the name 'qc-selected-samples'
          var existingInputs = form.querySelectorAll('input[name="qc-selected-samples"]');

--- a/frontend/app/blueprints/groups/templates/shared.html
+++ b/frontend/app/blueprints/groups/templates/shared.html
@@ -1,4 +1,4 @@
-{% from  'sidebar.html' import qc_classification_form_fields  %}
+{% from  'sidebar.html' import qc_classification_form_fields, qc_form_controls_js  %}
 
 {% macro add_to_basket_btn() %}
 <button id="add-to-basket-btn" class="btn btn-sm btn-outline-success ms-4" 
@@ -152,7 +152,10 @@ document.getElementById("similar-samples-threshold").addEventListener("input", (
         </form>
     </div>
     <script>
-     // Add data from JS table to qc bulk edit form before submit
+     // QC form controls:
+     {{ qc_form_controls_js() }}
+
+     // Add data from JS table to QC form before dispatching POST
      const qcForm = document.getElementById("qc-form-control");
      qcForm.addEventListener("submit", (e) => {
          e.preventDefault();
@@ -188,45 +191,5 @@ document.getElementById("similar-samples-threshold").addEventListener("input", (
              form.appendChild(input);
          });
      }
-
-     // QC Dropdown event listeners
-     document.getElementById("passed-qc-btn").addEventListener("click", (e) => {
-         // Clear QC-fail fields
-         const select = document.getElementById("failed-qc-action")
-         select.disabled = true
-         select.hidden = true
-         select.value = "0"
-         const textArea = document.getElementById("failed-qc-comment-container")
-         textArea.hidden = true
-
-         // Enable submit
-         const submitButton = document.getElementById("qc-submit-btn")
-         submitButton.disabled = false;
-     })
-     document.getElementById("failed-qc-btn").addEventListener("click", (e) => {
-         // enable selections of actions to take after rejecting a sample
-         const select = document.getElementById("failed-qc-action")
-         select.disabled = false
-         select.hidden = false
-         const textArea = document.getElementById("failed-qc-comment-container")
-         textArea.hidden = false
-
-         // Do not allow form submit unless follow-up action selected
-         const submitButton = document.getElementById("qc-submit-btn")
-         if (select.value === '0') {
-             submitButton.disabled = true;
-         }
-
-     })
-     // Force followup action selection when failing samples:
-     document.getElementById("failed-qc-action").addEventListener("change", (e) => {
-         const select = document.getElementById("failed-qc-action")
-         const submitButton = document.getElementById("qc-submit-btn")
-         if (select.value === '0') {
-             submitButton.disabled = true;
-         } else {
-             submitButton.disabled = false;
-         }
-     })
     </script>
 {% endmacro %}

--- a/frontend/app/blueprints/groups/templates/shared.html
+++ b/frontend/app/blueprints/groups/templates/shared.html
@@ -124,72 +124,116 @@ document.getElementById("similar-samples-threshold").addEventListener("input", (
             - bad_qc_actions : List[str]    List of selectable follow-up actions for failed samples
 
     #}
-    <div id="find-similar-dropdown" class="dropdown">
-        <button
-            id="toggle-qc-btn"
-            class="btn btn-sm btn-outline-secondary dropdown-toggle ms-4"
-            data-bs-toggle="dropdown" data-bs-auto-close="outside" enabled>
+<div id="find-similar-dropdown" class="dropdown">
+    <button
+        id="toggle-qc-btn"
+        class="btn btn-sm btn-outline-secondary dropdown-toggle ms-4"
+        data-bs-toggle="dropdown" data-bs-auto-close="outside" enabled>
         Toggle QC
-        </button>
-        <form class="dropdown-menu dropdown-menu-end p-2 needs-validation" action="{{ url_for('samples.update_qc_classification', sample_id=sample_id) }}" method="post">
-            <span class="btn-group btn-group-sm col-auto" role="group" aria-label="Sample qc rejection group">
-                <label class="btn btn-outline-success" for="passed-qc-btn"><i class="bi bi-hand-thumbs-up"></i></label>
-                <input
-                    type="radio"
-                    class="btn-check btn-sm"
-                    name="qc-validation"
-                    id="passed-qc-btn"
-                    autocomplete="off"
-                    value="passed"
-                >
-                <label class="btn btn-outline-danger" for="failed-qc-btn"><i class="bi bi-hand-thumbs-down"></i></label>
-                <input
-                    type="radio"
-                    class="btn-check btn-sm"
-                    name="qc-validation"
-                    id="failed-qc-btn"
-                    autocomplete="off"
-                    value="failed"
-                >
-            </span>
-            <fieldset id="failed-qc-controls">
-                <div class="row pb-2">
-                    <div class="col-auto d-flex flex-row">
-                        <select
-                            id="failed-qc-action"
-                            class="form-select form-select-sm"
-                            name="qc-action"
-                            aria-label="Action on failed sample"
-                            disabled
-                            hidden
-                        >
-                            <option selected disabled>Select action</option>
-                            {% for action in bad_qc_actions %}
-                            <option value="{{action}}">{{action | capitalize}}</option>
-                            {% endfor %}
-                        </select>
-                    </div>
+    </button>
+    <form
+        class="needs-validation"
+        method="post"
+        id="qc-form-control"
+        action="{{ url_for('groups.update_qc_classification') }}"
+    >
+        <div id="qc-dropdown-contents" class="dropdown-menu dropdown-menu-end p-2">
+            <div class ="row pb-2">
+                <div class="btn-group btn-group-sm col-auto" role="group" aria-label="Sample qc rejection group">
+                    <input
+                        type="radio"
+                        class="btn-check btn-sm"
+                        name="qc-validation"
+                        id="passed-qc-btn"
+                        autocomplete="off"
+                        value="passed"
+                    >
+                    <label class="btn btn-outline-success" for="passed-qc-btn"><i class="bi bi-hand-thumbs-up"></i></label>
+                    <input
+                        type="radio"
+                        class="btn-check btn-sm"
+                        name="qc-validation"
+                        id="failed-qc-btn"
+                        autocomplete="off"
+                        value="failed"
+                    >
+                    <label class="btn btn-outline-danger" for="failed-qc-btn"><i class="bi bi-hand-thumbs-down"></i></label>
                 </div>
-                <div id="failed-qc-comment-container" class="row">
-                    <div id="" class="col-auto">
-                        <label class="text-muted" for="failed-qc-comment">Comment</label>
-                        <textarea
-                            type="text"
-                            class="form-control"
-                            name="qc-comment"
-                            id="failed-qc-comment"
-                        ></textarea>
-                    </div>
+                <div class="col-auto d-flex flex-row">
+                    <select
+                        id="failed-qc-action"
+                        class="form-select form-select-sm"
+                        name="qc-action"
+                        aria-label="Action on failed sample"
+                        disabled
+                        hidden
+                    >
+                        <option selected disabled>Select action</option>
+                        {% for action in bad_qc_actions %}
+                        <option value="{{action}}">{{action | capitalize}}</option>
+                        {% endfor %}
+                    </select>
                 </div>
-            </fieldset>
+                <div class="col-auto">
+                    <label class="text-muted" for="failed-qc-comment">Comment</label>
+                    <textarea
+                        type="text"
+                        class="form-control"
+                        name="qc-comment"
+                        id="failed-qc-comment"
+                        disabled
+                        hidden
+                    ></textarea>
+                </div>
+            </div>
+
             <div class="row">
                 <div class="col-auto">
                     <button type="submit" class="btn btn-sm btn-outline-secondary mt-2">Confirm</button>
                 </div>
             </div>
-        </form>
-    </div>
+        </div>
+    </form>
+</div>
     <script>
+
+     let qcForm = document.getElementById("qc-form-control");
+
+     qcForm.addEventListener("submit", (e) => {
+         e.preventDefault();
+         addSelectedSamplesToQcForm(qcForm)
+         qcForm.submit()
+     });
+
+     /**
+      * Adds selected samples to HTML form by creating and appending
+      * hidden input elements with the sample IDs.
+      *
+      * @param   {HTMLFormElement}  form    The HTML form element to which the selected samples will be added.
+      */
+     function addSelectedSamplesToQcForm(form) {
+         // Retrieve selected samples from sessionStorage
+         var selectedSamples = JSON.parse(sessionStorage.getItem("selectedSamples"));
+
+         // Remove existing hidden inputs with the name 'qc-selected-samples'
+         var existingInputs = form.querySelectorAll('input[name="qc-selected-samples"]');
+         existingInputs.forEach(function(existingInput) {
+             existingInput.parentNode.removeChild(existingInput);
+         });
+
+         // Iterate over the selectedSamples array and add as hidden inputs to the form
+         selectedSamples.forEach(function(sampleId) {
+             // Create a hidden input element
+             var input = document.createElement('input');
+             input.type = 'hidden';
+             input.name = 'qc-selected-samples'; // Adjust the name as needed
+             input.value = sampleId;
+
+             // Append the input element to the form
+             form.appendChild(input);
+         });
+     }
+
      // QC Dropdown event listeners
      document.getElementById("passed-qc-btn").addEventListener("click", (e) => {
         // disable selection of actions to take after passing a sample

--- a/frontend/app/blueprints/groups/templates/shared.html
+++ b/frontend/app/blueprints/groups/templates/shared.html
@@ -144,9 +144,9 @@ document.getElementById("similar-samples-threshold").addEventListener("input", (
             <div id="qc-dropdown-contents" class="dropdown-menu dropdown-menu-end p-2">
                 {{ qc_classification_form_fields(
                     bad_qc_actions=bad_qc_actions,
-                    selected_qc_status = None,
-                    selected_action = None,
-                    comment_text = None
+                    selected_qc_status = "",
+                    selected_action = "",
+                    comment_text = ""
                 ) }}
             </div>
         </form>

--- a/frontend/app/blueprints/groups/templates/shared.html
+++ b/frontend/app/blueprints/groups/templates/shared.html
@@ -124,7 +124,7 @@ document.getElementById("similar-samples-threshold").addEventListener("input", (
             - bad_qc_actions : List[str]    List of selectable follow-up actions for failed samples
 
     #}
-    <div id="find-similar-dropdown" class="dropdown">
+    <div id="qc-menu-dropdown" class="dropdown">
         <button
             id="toggle-qc-btn"
             class="btn btn-sm btn-outline-secondary dropdown-toggle ms-4"

--- a/frontend/app/blueprints/groups/templates/shared.html
+++ b/frontend/app/blueprints/groups/templates/shared.html
@@ -1,3 +1,5 @@
+{% from  'sidebar.html' import qc_classification_form_fields  %}
+
 {% macro add_to_basket_btn() %}
 <button id="add-to-basket-btn" class="btn btn-sm btn-outline-success ms-4" 
         onclick="addSelectedSamplesToBasket(this)" disabled>
@@ -140,63 +142,12 @@ document.getElementById("similar-samples-threshold").addEventListener("input", (
             action="{{ url_for('groups.update_qc_classification') }}"
         >
             <div id="qc-dropdown-contents" class="dropdown-menu dropdown-menu-end p-2">
-                <div class ="row pb-2">
-                    <div class="btn-group btn-group-sm col-auto" role="group" aria-label="Sample qc rejection group">
-                        <input
-                            type="radio"
-                            class="btn-check btn-sm"
-                            name="qc-validation"
-                            id="passed-qc-btn"
-                            autocomplete="off"
-                            value="passed"
-                        >
-                        <label class="btn btn-outline-success" for="passed-qc-btn"><i class="bi bi-hand-thumbs-up"></i></label>
-                        <input
-                            type="radio"
-                            class="btn-check btn-sm"
-                            name="qc-validation"
-                            id="failed-qc-btn"
-                            autocomplete="off"
-                            value="failed"
-                        >
-                        <label class="btn btn-outline-danger" for="failed-qc-btn"><i class="bi bi-hand-thumbs-down"></i></label>
-                    </div>
-                    <div class="col-auto d-flex flex-row">
-                        <select
-                            id="failed-qc-action"
-                            class="form-select form-select-sm"
-                            name="qc-action"
-                            aria-label="Action on failed sample"
-                            hidden
-                        >
-                            <option selected value="0" disabled>Select action</option>
-                            {% for action in bad_qc_actions %}
-                            <option value="{{action}}">{{action | capitalize}}</option>
-                            {% endfor %}
-                        </select>
-                    </div>
-                    <div id="failed-qc-comment-container" class="row" hidden>
-                        <div class="col-auto">
-                            <label class="text-muted" for="failed-qc-comment">Comment</label>
-                            <textarea
-                                type="text"
-                                class="form-control"
-                                name="qc-comment"
-                                id="failed-qc-comment"
-                            ></textarea>
-                        </div>
-                    </div>
-                </div>
-                <div class="row">
-                    <div class="col-auto">
-                        <button
-                            id="qc-submit-btn"
-                            type="submit"
-                            class="btn btn-sm btn-outline-secondary mt-2"
-                            disabled
-                        >Confirm</button>
-                    </div>
-                </div>
+                {{ qc_classification_form_fields(
+                    bad_qc_actions=bad_qc_actions,
+                    selected_qc_status = None,
+                    selected_action = None,
+                    comment_text = None
+                ) }}
             </div>
         </form>
     </div>

--- a/frontend/app/blueprints/groups/templates/shared.html
+++ b/frontend/app/blueprints/groups/templates/shared.html
@@ -124,81 +124,78 @@ document.getElementById("similar-samples-threshold").addEventListener("input", (
             - bad_qc_actions : List[str]    List of selectable follow-up actions for failed samples
 
     #}
-<div id="find-similar-dropdown" class="dropdown">
-    <button
-        id="toggle-qc-btn"
-        class="btn btn-sm btn-outline-secondary dropdown-toggle ms-4"
-        data-bs-toggle="dropdown" data-bs-auto-close="outside" enabled>
-        Toggle QC
-    </button>
-    <form
-        class="needs-validation"
-        method="post"
-        id="qc-form-control"
-        action="{{ url_for('groups.update_qc_classification') }}"
-    >
-        <div id="qc-dropdown-contents" class="dropdown-menu dropdown-menu-end p-2">
-            <div class ="row pb-2">
-                <div class="btn-group btn-group-sm col-auto" role="group" aria-label="Sample qc rejection group">
-                    <input
-                        type="radio"
-                        class="btn-check btn-sm"
-                        name="qc-validation"
-                        id="passed-qc-btn"
-                        autocomplete="off"
-                        value="passed"
-                    >
-                    <label class="btn btn-outline-success" for="passed-qc-btn"><i class="bi bi-hand-thumbs-up"></i></label>
-                    <input
-                        type="radio"
-                        class="btn-check btn-sm"
-                        name="qc-validation"
-                        id="failed-qc-btn"
-                        autocomplete="off"
-                        value="failed"
-                    >
-                    <label class="btn btn-outline-danger" for="failed-qc-btn"><i class="bi bi-hand-thumbs-down"></i></label>
+    <div id="find-similar-dropdown" class="dropdown">
+        <button
+            id="toggle-qc-btn"
+            class="btn btn-sm btn-outline-secondary dropdown-toggle ms-4"
+            data-bs-toggle="dropdown" data-bs-auto-close="outside" enabled>
+            Toggle QC
+        </button>
+        <form
+            class="needs-validation"
+            method="post"
+            id="qc-form-control"
+            action="{{ url_for('groups.update_qc_classification') }}"
+        >
+            <div id="qc-dropdown-contents" class="dropdown-menu dropdown-menu-end p-2">
+                <div class ="row pb-2">
+                    <div class="btn-group btn-group-sm col-auto" role="group" aria-label="Sample qc rejection group">
+                        <input
+                            type="radio"
+                            class="btn-check btn-sm"
+                            name="qc-validation"
+                            id="passed-qc-btn"
+                            autocomplete="off"
+                            value="passed"
+                        >
+                        <label class="btn btn-outline-success" for="passed-qc-btn"><i class="bi bi-hand-thumbs-up"></i></label>
+                        <input
+                            type="radio"
+                            class="btn-check btn-sm"
+                            name="qc-validation"
+                            id="failed-qc-btn"
+                            autocomplete="off"
+                            value="failed"
+                        >
+                        <label class="btn btn-outline-danger" for="failed-qc-btn"><i class="bi bi-hand-thumbs-down"></i></label>
+                    </div>
+                    <div class="col-auto d-flex flex-row">
+                        <select
+                            id="failed-qc-action"
+                            class="form-select form-select-sm"
+                            name="qc-action"
+                            aria-label="Action on failed sample"
+                            hidden
+                        >
+                            <option selected disabled>Select action</option>
+                            {% for action in bad_qc_actions %}
+                            <option value="{{action}}">{{action | capitalize}}</option>
+                            {% endfor %}
+                        </select>
+                    </div>
+                    <div id="failed-qc-comment-container" class="row" hidden>
+                        <div class="col-auto">
+                            <label class="text-muted" for="failed-qc-comment">Comment</label>
+                            <textarea
+                                type="text"
+                                class="form-control"
+                                name="qc-comment"
+                                id="failed-qc-comment"
+                            ></textarea>
+                        </div>
+                    </div>
                 </div>
-                <div class="col-auto d-flex flex-row">
-                    <select
-                        id="failed-qc-action"
-                        class="form-select form-select-sm"
-                        name="qc-action"
-                        aria-label="Action on failed sample"
-                        disabled
-                        hidden
-                    >
-                        <option selected disabled>Select action</option>
-                        {% for action in bad_qc_actions %}
-                        <option value="{{action}}">{{action | capitalize}}</option>
-                        {% endfor %}
-                    </select>
-                </div>
-                <div class="col-auto">
-                    <label class="text-muted" for="failed-qc-comment">Comment</label>
-                    <textarea
-                        type="text"
-                        class="form-control"
-                        name="qc-comment"
-                        id="failed-qc-comment"
-                        disabled
-                        hidden
-                    ></textarea>
-                </div>
-            </div>
 
-            <div class="row">
-                <div class="col-auto">
-                    <button type="submit" class="btn btn-sm btn-outline-secondary mt-2">Confirm</button>
+                <div class="row">
+                    <div class="col-auto">
+                        <button type="submit" class="btn btn-sm btn-outline-secondary mt-2">Confirm</button>
+                    </div>
                 </div>
             </div>
-        </div>
-    </form>
-</div>
+        </form>
+    </div>
     <script>
-
      let qcForm = document.getElementById("qc-form-control");
-
      qcForm.addEventListener("submit", (e) => {
          e.preventDefault();
          addSelectedSamplesToQcForm(qcForm)
@@ -213,7 +210,7 @@ document.getElementById("similar-samples-threshold").addEventListener("input", (
       */
      function addSelectedSamplesToQcForm(form) {
          // Retrieve selected samples from sessionStorage
-         var selectedSamples = JSON.parse(sessionStorage.getItem("selectedSamples"));
+         var selectedSamples = window.getSelectedRows()
 
          // Remove existing hidden inputs with the name 'qc-selected-samples'
          var existingInputs = form.querySelectorAll('input[name="qc-selected-samples"]');
@@ -227,7 +224,7 @@ document.getElementById("similar-samples-threshold").addEventListener("input", (
              var input = document.createElement('input');
              input.type = 'hidden';
              input.name = 'qc-selected-samples'; // Adjust the name as needed
-             input.value = sampleId['sample_id'];
+             input.value = sampleId
 
              // Append the input element to the form
              form.appendChild(input);
@@ -236,22 +233,23 @@ document.getElementById("similar-samples-threshold").addEventListener("input", (
 
      // QC Dropdown event listeners
      document.getElementById("passed-qc-btn").addEventListener("click", (e) => {
-        // disable selection of actions to take after passing a sample
+         // disable selection of actions to take after passing a sample
          e.stopPropagation();
-        const select = document.getElementById("failed-qc-action")
-        select.disabled = true
-        select.hidden = true
-        select.value = null
-        const textArea = document.getElementById("failed-qc-comment-container")
-        textArea.hidden = true
-        select.value = null
-    })
+         const select = document.getElementById("failed-qc-action")
+         select.disabled = true
+         select.hidden = true
+         select.value = null
+         const textArea = document.getElementById("failed-qc-comment-container")
+         textArea.hidden = true
+
+     })
      document.getElementById("failed-qc-btn").addEventListener("click", (e) => {
-        // enable selections of actions to take after rejecting a sample
-        const select = document.getElementById("failed-qc-action")
-        select.disabled = false
-        select.hidden = false
-        document.getElementById("failed-qc-comment-container").hidden = false
-    })
+         // enable selections of actions to take after rejecting a sample
+         const select = document.getElementById("failed-qc-action")
+         select.disabled = false
+         select.hidden = false
+         const textArea = document.getElementById("failed-qc-comment-container")
+         textArea.hidden = false
+     })
     </script>
 {% endmacro %}

--- a/frontend/app/blueprints/groups/templates/shared.html
+++ b/frontend/app/blueprints/groups/templates/shared.html
@@ -128,7 +128,9 @@ document.getElementById("similar-samples-threshold").addEventListener("input", (
         <button
             id="toggle-qc-btn"
             class="btn btn-sm btn-outline-secondary dropdown-toggle ms-4"
-            data-bs-toggle="dropdown" data-bs-auto-close="outside" enabled>
+            data-bs-toggle="dropdown" data-bs-auto-close="outside"
+            disabled
+        >
             Toggle QC
         </button>
         <form

--- a/frontend/app/blueprints/groups/templates/shared.html
+++ b/frontend/app/blueprints/groups/templates/shared.html
@@ -227,7 +227,7 @@ document.getElementById("similar-samples-threshold").addEventListener("input", (
              var input = document.createElement('input');
              input.type = 'hidden';
              input.name = 'qc-selected-samples'; // Adjust the name as needed
-             input.value = sampleId;
+             input.value = sampleId['sample_id'];
 
              // Append the input element to the form
              form.appendChild(input);

--- a/frontend/app/blueprints/groups/templates/shared.html
+++ b/frontend/app/blueprints/groups/templates/shared.html
@@ -114,3 +114,100 @@ document.getElementById("similar-samples-threshold").addEventListener("input", (
     document.getElementById("similar-samples-button").disabled = isNaN(parseInt(thresholdValue))
 });
 {% endmacro %}
+
+{% macro qc_bulk_toggle(bad_qc_actions) %}
+    {#
+
+        Button interacting with sample list in groups. Activates pop up dialog when used.
+
+        Inputs:
+            - bad_qc_actions : List[str]    List of selectable follow-up actions for failed samples
+
+    #}
+    <div id="find-similar-dropdown" class="dropdown">
+        <button
+            id="toggle-qc-btn"
+            class="btn btn-sm btn-outline-secondary dropdown-toggle ms-4"
+            data-bs-toggle="dropdown" data-bs-auto-close="outside" enabled>
+        Toggle QC
+        </button>
+        <form class="dropdown-menu dropdown-menu-end p-2 needs-validation" action="{{ url_for('samples.update_qc_classification', sample_id=sample_id) }}" method="post">
+            <span class="btn-group btn-group-sm col-auto" role="group" aria-label="Sample qc rejection group">
+                <label class="btn btn-outline-success" for="passed-qc-btn"><i class="bi bi-hand-thumbs-up"></i></label>
+                <input
+                    type="radio"
+                    class="btn-check btn-sm"
+                    name="qc-validation"
+                    id="passed-qc-btn"
+                    autocomplete="off"
+                    value="passed"
+                >
+                <label class="btn btn-outline-danger" for="failed-qc-btn"><i class="bi bi-hand-thumbs-down"></i></label>
+                <input
+                    type="radio"
+                    class="btn-check btn-sm"
+                    name="qc-validation"
+                    id="failed-qc-btn"
+                    autocomplete="off"
+                    value="failed"
+                >
+            </span>
+            <fieldset id="failed-qc-controls">
+                <div class="row pb-2">
+                    <div class="col-auto d-flex flex-row">
+                        <select
+                            id="failed-qc-action"
+                            class="form-select form-select-sm"
+                            name="qc-action"
+                            aria-label="Action on failed sample"
+                            disabled
+                            hidden
+                        >
+                            <option selected disabled>Select action</option>
+                            {% for action in bad_qc_actions %}
+                            <option value="{{action}}">{{action | capitalize}}</option>
+                            {% endfor %}
+                        </select>
+                    </div>
+                </div>
+                <div id="failed-qc-comment-container" class="row">
+                    <div id="" class="col-auto">
+                        <label class="text-muted" for="failed-qc-comment">Comment</label>
+                        <textarea
+                            type="text"
+                            class="form-control"
+                            name="qc-comment"
+                            id="failed-qc-comment"
+                        ></textarea>
+                    </div>
+                </div>
+            </fieldset>
+            <div class="row">
+                <div class="col-auto">
+                    <button type="submit" class="btn btn-sm btn-outline-secondary mt-2">Confirm</button>
+                </div>
+            </div>
+        </form>
+    </div>
+    <script>
+     // QC Dropdown event listeners
+     document.getElementById("passed-qc-btn").addEventListener("click", (e) => {
+        // disable selection of actions to take after passing a sample
+         e.stopPropagation();
+        const select = document.getElementById("failed-qc-action")
+        select.disabled = true
+        select.hidden = true
+        select.value = null
+        const textArea = document.getElementById("failed-qc-comment-container")
+        textArea.hidden = true
+        select.value = null
+    })
+     document.getElementById("failed-qc-btn").addEventListener("click", (e) => {
+        // enable selections of actions to take after rejecting a sample
+        const select = document.getElementById("failed-qc-action")
+        select.disabled = false
+        select.hidden = false
+        document.getElementById("failed-qc-comment-container").hidden = false
+    })
+    </script>
+{% endmacro %}

--- a/frontend/app/blueprints/groups/templates/shared.html
+++ b/frontend/app/blueprints/groups/templates/shared.html
@@ -131,7 +131,7 @@ document.getElementById("similar-samples-threshold").addEventListener("input", (
             data-bs-toggle="dropdown" data-bs-auto-close="outside"
             disabled
         >
-            Toggle QC
+            Set QC status
         </button>
         <form
             class="needs-validation"
@@ -169,7 +169,7 @@ document.getElementById("similar-samples-threshold").addEventListener("input", (
                             aria-label="Action on failed sample"
                             hidden
                         >
-                            <option selected disabled>Select action</option>
+                            <option selected value="0" disabled>Select action</option>
                             {% for action in bad_qc_actions %}
                             <option value="{{action}}">{{action | capitalize}}</option>
                             {% endfor %}
@@ -187,16 +187,21 @@ document.getElementById("similar-samples-threshold").addEventListener("input", (
                         </div>
                     </div>
                 </div>
-
                 <div class="row">
                     <div class="col-auto">
-                        <button type="submit" class="btn btn-sm btn-outline-secondary mt-2">Confirm</button>
+                        <button
+                            id="qc-submit-btn"
+                            type="submit"
+                            class="btn btn-sm btn-outline-secondary mt-2"
+                            disabled
+                        >Confirm</button>
                     </div>
                 </div>
             </div>
         </form>
     </div>
     <script>
+     // Add data from JS table to qc bulk edit form before submit
      let qcForm = document.getElementById("qc-form-control");
      qcForm.addEventListener("submit", (e) => {
          e.preventDefault();
@@ -235,15 +240,17 @@ document.getElementById("similar-samples-threshold").addEventListener("input", (
 
      // QC Dropdown event listeners
      document.getElementById("passed-qc-btn").addEventListener("click", (e) => {
-         // disable selection of actions to take after passing a sample
-         e.stopPropagation();
+         // Clear QC-fail fields
          const select = document.getElementById("failed-qc-action")
          select.disabled = true
          select.hidden = true
-         select.value = null
+         select.value = "0"
          const textArea = document.getElementById("failed-qc-comment-container")
          textArea.hidden = true
 
+         // Enable submit
+         const submitButton = document.getElementById("qc-submit-btn")
+         submitButton.disabled = false;
      })
      document.getElementById("failed-qc-btn").addEventListener("click", (e) => {
          // enable selections of actions to take after rejecting a sample
@@ -252,6 +259,23 @@ document.getElementById("similar-samples-threshold").addEventListener("input", (
          select.hidden = false
          const textArea = document.getElementById("failed-qc-comment-container")
          textArea.hidden = false
+
+         // Do not allow form submit unless follow-up action selected
+         const submitButton = document.getElementById("qc-submit-btn")
+         if (select.value === '0') {
+             submitButton.disabled = true;
+         }
+
+     })
+     // Force followup action selection when failing samples:
+     document.getElementById("failed-qc-action").addEventListener("change", (e) => {
+         const select = document.getElementById("failed-qc-action")
+         const submitButton = document.getElementById("qc-submit-btn")
+         if (select.value === '0') {
+             submitButton.disabled = true;
+         } else {
+             submitButton.disabled = false;
+         }
      })
     </script>
 {% endmacro %}

--- a/frontend/app/blueprints/groups/templates/shared.html
+++ b/frontend/app/blueprints/groups/templates/shared.html
@@ -221,12 +221,12 @@ document.getElementById("similar-samples-threshold").addEventListener("input", (
 
          // Remove existing hidden inputs with the name 'qc-selected-samples'
          var existingInputs = form.querySelectorAll('input[name="qc-selected-samples"]');
-         existingInputs.forEach(function(existingInput) {
+         existingInputs.forEach(existingInput => {
              existingInput.parentNode.removeChild(existingInput);
          });
 
          // Iterate over the selectedSamples array and add as hidden inputs to the form
-         selectedSamples.forEach(function(sampleId) {
+         selectedSamples.forEach(sampleId => {
              // Create a hidden input element
              var input = document.createElement('input');
              input.type = 'hidden';

--- a/frontend/app/blueprints/groups/views.py
+++ b/frontend/app/blueprints/groups/views.py
@@ -51,9 +51,9 @@ def groups() -> str:
     basket = session
 
     bad_qc_actions = [member.value for member in BadSampleQualityAction]
-    selected_samples = request.args.getlist("samples")
 
-    current_app.logger.debug(selected_samples)
+    # Pre-select samples in sample table:
+    selected_samples = request.args.getlist("samples")
 
     return render_template(
         "groups.html",
@@ -195,7 +195,7 @@ def update_qc_classification():
             )
         except Exception as error:
             current_app.logger.exception(
-                "Encountered error when updating QC status for sample %s", sample_id
+                "Encountered error when updating QC status for sample %s:", sample_id
             )
             flash(str(error), "danger")
 

--- a/frontend/app/blueprints/groups/views.py
+++ b/frontend/app/blueprints/groups/views.py
@@ -175,10 +175,10 @@ def update_qc_classification():
 
     # build data to store in db
     result = request.form.get("qc-validation", None)
-    if result == QualityControlResult.PASSED:
+    if result == QualityControlResult.PASSED.value:
         action = None
         comment = ""
-    elif result == QualityControlResult.FAILED:
+    elif result == QualityControlResult.FAILED.value:
         comment = request.form.get("qc-comment", "")
         action = request.form.get("qc-action", "")
     else:

--- a/frontend/app/blueprints/groups/views.py
+++ b/frontend/app/blueprints/groups/views.py
@@ -17,7 +17,7 @@ from app.bonsai import (
     update_group,
     update_sample_qc_classification,
 )
-from app.models import PhenotypeType
+from app.models import PhenotypeType, BadSampleQualityAction
 
 LOG = logging.getLogger(__name__)
 
@@ -50,6 +50,8 @@ def groups() -> str:
     all_samples = get_samples(token, limit=0, skip=0)
     basket = session
 
+    bad_qc_actions = [member.value for member in BadSampleQualityAction]
+
     return render_template(
         "groups.html",
         title="Groups",
@@ -57,6 +59,7 @@ def groups() -> str:
         samples=all_samples,
         basket=basket,
         token=current_user.get_id().get("token"),
+        bad_qc_actions=bad_qc_actions,
     )
 
 
@@ -181,6 +184,9 @@ def update_qc_classification():
                 comment=comment,
             )
         except Exception as error:
+            current_app.logger.exception(
+                "Encountered error when updating QC status for sample %s", sample_id
+            )
             flash(str(error), "danger")
 
     return redirect(url_for("groups.groups"))

--- a/frontend/app/blueprints/groups/views.py
+++ b/frontend/app/blueprints/groups/views.py
@@ -162,10 +162,10 @@ def update_qc_classification():
 
     selected_samples = request.form.getlist("qc-selected-samples")
 
-    current_app.logger.debug("Processing request to set QC for %s", selected_samples)
+    LOG.debug("Processing request to set QC for %s", selected_samples)
 
     if not selected_samples:
-        current_app.logger.warning("Received request to set QC but no selected samples")
+        LOG.warning("Received request to set QC but no selected samples")
         flash(
             "No samples selected for QC status update. Please choose at least one sample.",
             "warning",
@@ -194,7 +194,7 @@ def update_qc_classification():
                 comment=comment,
             )
         except Exception as error:
-            current_app.logger.exception(
+            LOG.exception(
                 "Encountered error when updating QC status for sample %s:", sample_id
             )
             flash(str(error), "danger")

--- a/frontend/app/blueprints/groups/views.py
+++ b/frontend/app/blueprints/groups/views.py
@@ -17,7 +17,7 @@ from app.bonsai import (
     update_group,
     update_sample_qc_classification,
 )
-from app.models import PhenotypeType, BadSampleQualityAction
+from app.models import PhenotypeType, BadSampleQualityAction, QualityControlResult
 
 LOG = logging.getLogger(__name__)
 
@@ -175,10 +175,10 @@ def update_qc_classification():
 
     # build data to store in db
     result = request.form.get("qc-validation", None)
-    if result == "passed":
+    if result == QualityControlResult.PASSED:
         action = None
         comment = ""
-    elif result == "failed":
+    elif result == QualityControlResult.FAILED:
         comment = request.form.get("qc-comment", "")
         action = request.form.get("qc-action", "")
     else:

--- a/frontend/app/blueprints/sample/templates/sample.html
+++ b/frontend/app/blueprints/sample/templates/sample.html
@@ -472,14 +472,12 @@
 
     // handle sample qc rejections
     document.getElementById("passed-qc-btn").addEventListener("click", () => {
-        // enable selction of actions to take after rejecting a sample
+        // disable selection of actions to take after rejecting a sample
         const select = document.getElementById("failed-qc-action")
         select.disabled = true
         select.hidden = true
-        select.value = null
         const textArea = document.getElementById("failed-qc-comment-container")
         textArea.hidden = true
-        select.value = null
     })
     document.getElementById("failed-qc-btn").addEventListener("click", () => {
         // enable selction of actions to take after rejecting a sample

--- a/frontend/app/blueprints/sample/templates/sample.html
+++ b/frontend/app/blueprints/sample/templates/sample.html
@@ -1,5 +1,5 @@
 {% extends "layout.html" %}
-{% from "sidebar.html" import sidebar, table_of_content %}
+{% from "sidebar.html" import sidebar, table_of_content, qc_form_controls_js %}
 {% from "cards.html" import resistance_summary_card, resistance_table_card, virulence_card, species_prediction_card %}
 
 {% block css %}
@@ -460,6 +460,8 @@
     //const tooltipTriggerList = document.querySelectorAll('[data-bs-toggle="tooltip"]')
     //const tooltipList = [...tooltipTriggerList].map(tooltipTriggerEl => new bootstrap.Tooltip(tooltipTriggerEl))
 
+    {{ qc_form_controls_js() }}
+
     function removeComment(btn) {
         // remove comment from sample
         const apiURL = "{{ config.BONSAI_API_URL }}"
@@ -470,21 +472,6 @@
         })
     }
 
-    // handle sample qc rejections
-    document.getElementById("passed-qc-btn").addEventListener("click", () => {
-        // disable selection of actions to take after rejecting a sample
-        const select = document.getElementById("failed-qc-action")
-        select.disabled = true
-        select.hidden = true
-        const textArea = document.getElementById("failed-qc-comment-container")
-        textArea.hidden = true
-    })
-    document.getElementById("failed-qc-btn").addEventListener("click", () => {
-        // enable selction of actions to take after rejecting a sample
-        const select = document.getElementById("failed-qc-action")
-        select.disabled = false
-        select.hidden = false
-        document.getElementById("failed-qc-comment-container").hidden = false
-    })
+
 </script>
 {% endblock content %}

--- a/frontend/app/blueprints/sample/templates/sidebar.html
+++ b/frontend/app/blueprints/sample/templates/sidebar.html
@@ -29,51 +29,108 @@
 </form>
 {% endmacro %}
 
+{% macro qc_classification_form_fields(bad_qc_actions, selected_qc_status, selected_action, comment_text) %}
+    {#
 
-{% macro qc_classification(cls, bad_qc_actions, sample_id) %}
-<h6 class="sidebar-heading mt-4 mb-1 text-muted text-uppercase">Quality control</h6>
-<form action="{{ url_for('samples.update_qc_classification', sample_id=sample_id) }}" 
-      method="post" name="qc-classification" class="form-control">
-    <div class="row pb-2">
-        <div class="btn-group btn-group-sm col-auto" role="group" aria-label="Sample qc rejection group">
-            <input 
-                type="radio" class="btn-check btn-sm" name="qc-validation" 
-                id="passed-qc-btn" autocomplete="off" value="passed"
-                {% if cls.status == "passed" %}checked{% endif  %}
-            >
-            <label class="btn btn-outline-success" for="passed-qc-btn"><i class="bi bi-hand-thumbs-up"></i></label>
-            <input type="radio" class="btn-check btn-sm" name="qc-validation"
-                id="failed-qc-btn" autocomplete="off" value="failed"
-                {% if cls.status == "failed" %}checked{% endif  %}
-            >
-            <label class="btn btn-outline-danger" for="failed-qc-btn"><i class="bi bi-hand-thumbs-down"></i></label>
-        </div>
-        <div class="col-auto d-flex flex-row">
-            <select id="failed-qc-action" class="form-select form-select-sm" 
-                    name="qc-action" aria-label="Action on failed sample" disabled hidden>
-                <option selected disabled>Select action</option>
-                {% for action in bad_qc_actions %}
-                    <option 
+        Form fields for setting QC status.
+
+        Inputs:
+        - bad_qc_actions:       List[str]   List of selectable follow-up actions for failed samples
+        - selected_qc_status:   str | None  Sample QC status used for pre-selecting QC checkbox.
+        - selected_action:      str | None  Selected follow-up action for failed samples.
+        - comment_text:         str | None  Comment text.
+
+    #}
+    <fieldset id="qc-form-fields">
+        <div class="row pb-2">
+            <div
+                class="btn-group btn-group-sm col-auto"
+                role="group"
+                aria-label="Sample qc rejection group">
+                <input
+                    type="radio" class="btn-check btn-sm" name="qc-validation"
+                    id="passed-qc-btn" autocomplete="off" value="passed"
+                    {% if selected_qc_status == "passed" %}checked{% endif %}
+                >
+                <label class="btn btn-outline-success" for="passed-qc-btn"><i class="bi bi-hand-thumbs-up"></i></label>
+                <input type="radio" class="btn-check btn-sm" name="qc-validation"
+                       id="failed-qc-btn" autocomplete="off" value="failed"
+                       {% if selected_qc_status == "failed" %}checked{% endif %}
+                >
+                <label class="btn btn-outline-danger" for="failed-qc-btn"><i class="bi bi-hand-thumbs-down"></i></label>
+            </div>
+            <div class="col-auto d-flex flex-row">
+                <select
+                    id="failed-qc-action"
+                    class="form-select form-select-sm"
+                    name="qc-action"
+                    aria-label="Action on failed sample"
+                    {% if selected_qc_status != "failed" %}
+                    disabled
+                    hidden
+                    {% endif  %}
+                >
+                    <option
+                        value=""
+                        selected
+                        disabled
+                    >
+                        Select action
+                    </option>
+                    {% for action in bad_qc_actions %}
+                    <option
                         value="{{action}}"
-                        {% if cls.action == action %}selected{% endif %}
+                        {% if selected_action == action %}selected{% endif %}
                     >{{action | capitalize}}</option>
-                {% endfor %}
-            </select>
+                    {% endfor %}
+                </select>
+            </div>
         </div>
-    </div>
-    <div id="failed-qc-comment-container" class="row" {% if cls.status != "failed" %}hidden{% endif %}>
-        <div id="" class="col-auto">
-            <label class="text-muted" for="failed-qc-comment">Comment</label>
-            <textarea type="text" class="form-control" name="qc-comment" id="failed-qc-comment"
-            >{{cls.comment}}</textarea>
+        <div id="failed-qc-comment-container" class="row" {% if selected_qc_status != "failed" %}hidden{% endif %}>
+            <div id="" class="col-auto">
+                <label class="text-muted" for="failed-qc-comment">Comment</label>
+                <textarea type="text" class="form-control" name="qc-comment" id="failed-qc-comment"
+                >{{comment_text}}</textarea>
+            </div>
         </div>
-    </div>
-    <div class="row">
-        <div class="col-auto">
-            <button type="submit" class="btn btn-sm btn-outline-secondary mt-2">Confirm</button>
+        <div class="row">
+            <div class="col-auto">
+                <button
+                    id="qc-submit-btn"
+                    type="submit"
+                    class="btn btn-sm btn-outline-secondary mt-2"
+                    disabled
+                >Confirm</button>
+            </div>
         </div>
-    </div>
-</form>
+    </fieldset>
+{% endmacro %}
+
+{% macro qc_classification(sample_qc_classification_obj, bad_qc_actions, sample_id) %}
+    {#
+
+        Sidebar UI section for setting QC status in sample-view sidebar
+
+        Inputs:
+        - qc_classification_obj     SampleQcClassification  Sample QC settings
+        - bad_qc_actions:           List[str]               List of selectable follow-up actions for failed samples
+        - sample_id:                str                     Current sample id
+
+    #}
+    <h6 class="sidebar-heading mt-4 mb-1 text-muted text-uppercase">Quality control</h6>
+    <form
+        action="{{ url_for('samples.update_qc_classification', sample_id=sample_id) }}"
+        method="post"
+        name="qc-classification"
+        class="form-control"
+    >
+        {{ qc_classification_form_fields(
+        bad_qc_actions=bad_qc_actions,
+        selected_qc_status=sample_qc_classification_obj.status,
+        selected_action=sample_qc_classification_obj.action,
+        comment_text=sample_qc_classification_obj.comment
+        ) }}
+    </form>
 {% endmacro %}
 
 {% macro sidebar(sample, bad_qc_actions) %}

--- a/frontend/app/blueprints/sample/templates/sidebar.html
+++ b/frontend/app/blueprints/sample/templates/sidebar.html
@@ -125,10 +125,6 @@
         select.value = "0"
         const textArea = document.getElementById("failed-qc-comment-container")
         textArea.hidden = true
-
-        // Enable submit button
-        const submitButton = document.getElementById("qc-submit-btn")
-        submitButton.disabled = false;
     })
 
     // When failing samples:
@@ -139,24 +135,22 @@
         select.hidden = false
         const textArea = document.getElementById("failed-qc-comment-container")
         textArea.hidden = false
+     })
 
-        // Do not enable submit unless follow-up action selected
+    //On any change in the form:
+    document.getElementById("qc-form-fields").addEventListener("change", (e) => {
+        // Force followup action selection when failing samples by disabling submit btn:
+        const qc_status = document.querySelector("input[name='qc-validation']:checked").value
+        const select = document.getElementById("failed-qc-action")
         const submitButton = document.getElementById("qc-submit-btn")
-        if (select.value === '0') {
-            submitButton.disabled = true;
-        }
-     })
 
-     // Force followup action selection when failing samples:
-     document.getElementById("failed-qc-action").addEventListener("change", (e) => {
-         const select = document.getElementById("failed-qc-action")
-         const submitButton = document.getElementById("qc-submit-btn")
-         if (select.value === '0') {
-             submitButton.disabled = true;
-         } else {
-             submitButton.disabled = false;
-         }
-     })
+        if (select.value === '' && qc_status === "failed") {
+            submitButton.disabled = true;
+        } else {
+            submitButton.disabled = false;
+        }
+    })
+
 {% endmacro %}
 
 

--- a/frontend/app/blueprints/sample/templates/sidebar.html
+++ b/frontend/app/blueprints/sample/templates/sidebar.html
@@ -106,6 +106,60 @@
     </fieldset>
 {% endmacro %}
 
+{% macro qc_form_controls_js() %}
+    {#
+
+       JS enhancements for QC form controls.
+
+        - Reset controls when toggling QC status in QC form
+        - Disable/enable form submit btn based on input validation
+
+    #}
+
+    // When passing samples:
+    document.getElementById("passed-qc-btn").addEventListener("click", (e) => {
+        // Clear QC-fail fields
+        const select = document.getElementById("failed-qc-action")
+        select.disabled = true
+        select.hidden = true
+        select.value = "0"
+        const textArea = document.getElementById("failed-qc-comment-container")
+        textArea.hidden = true
+
+        // Enable submit button
+        const submitButton = document.getElementById("qc-submit-btn")
+        submitButton.disabled = false;
+    })
+
+    // When failing samples:
+    document.getElementById("failed-qc-btn").addEventListener("click", (e) => {
+        // Enable selections of actions to take after rejecting a sample:
+        const select = document.getElementById("failed-qc-action")
+        select.disabled = false
+        select.hidden = false
+        const textArea = document.getElementById("failed-qc-comment-container")
+        textArea.hidden = false
+
+        // Do not enable submit unless follow-up action selected
+        const submitButton = document.getElementById("qc-submit-btn")
+        if (select.value === '0') {
+            submitButton.disabled = true;
+        }
+     })
+
+     // Force followup action selection when failing samples:
+     document.getElementById("failed-qc-action").addEventListener("change", (e) => {
+         const select = document.getElementById("failed-qc-action")
+         const submitButton = document.getElementById("qc-submit-btn")
+         if (select.value === '0') {
+             submitButton.disabled = true;
+         } else {
+             submitButton.disabled = false;
+         }
+     })
+{% endmacro %}
+
+
 {% macro qc_classification(sample_qc_classification_obj, bad_qc_actions, sample_id) %}
     {#
 

--- a/frontend/app/blueprints/sample/templates/sidebar.html
+++ b/frontend/app/blueprints/sample/templates/sidebar.html
@@ -30,7 +30,7 @@
 {% endmacro %}
 
 
-{% macro qc_classificaion(cls, bad_qc_actions, sample_id) %}
+{% macro qc_classification(cls, bad_qc_actions, sample_id) %}
 <h6 class="sidebar-heading mt-4 mb-1 text-muted text-uppercase">Quality control</h6>
 <form action="{{ url_for('samples.update_qc_classification', sample_id=sample_id) }}" 
       method="post" name="qc-classification" class="form-control">
@@ -95,7 +95,7 @@
         </li>
     </ul>
 
-    {{ qc_classificaion(sample.qc_status, bad_qc_actions, sample.sample_id) }}
+    {{ qc_classification(sample.qc_status, bad_qc_actions, sample.sample_id) }}
     <h6 class="sidebar-heading mt-4 mb-1 text-muted text-uppercase">Comments</h6>
     {{ comment_area(sample) }}
 </div>

--- a/frontend/app/blueprints/sample/views.py
+++ b/frontend/app/blueprints/sample/views.py
@@ -153,10 +153,10 @@ def update_qc_classification(sample_id: str) -> str:
 
     # build data to store in db
     result = request.form.get("qc-validation", None)
-    if result == QualityControlResult.PASSED:
+    if result == QualityControlResult.PASSED.value:
         action = None
         comment = ""
-    elif result == QualityControlResult.FAILED:
+    elif result == QualityControlResult.FAILED.value:
         comment = request.form.get("qc-comment", "")
         action = request.form.get("qc-action", "")
     else:

--- a/frontend/app/blueprints/sample/views.py
+++ b/frontend/app/blueprints/sample/views.py
@@ -12,7 +12,9 @@ from app.bonsai import (
     remove_comment_from_sample,
     update_sample_qc_classification,
 )
-from app.models import BadSampleQualityAction
+
+from app.models import BadSampleQualityAction, QualityControlResult
+
 from flask import (
     Blueprint,
     current_app,
@@ -151,10 +153,10 @@ def update_qc_classification(sample_id: str) -> str:
 
     # build data to store in db
     result = request.form.get("qc-validation", None)
-    if result == "passed":
+    if result == QualityControlResult.PASSED:
         action = None
         comment = ""
-    elif result == "failed":
+    elif result == QualityControlResult.FAILED:
         comment = request.form.get("qc-comment", "")
         action = request.form.get("qc-action", "")
     else:

--- a/frontend/app/bonsai.py
+++ b/frontend/app/bonsai.py
@@ -264,7 +264,7 @@ def remove_comment_from_sample(headers: CaseInsensitiveDict, **kwargs):
 
 @api_authentication
 def update_sample_qc_classification(headers: CaseInsensitiveDict, **kwargs):
-    """Update the qc classificaiton of a sample"""
+    """Update the qc classification of a sample"""
     if "sample_id" not in kwargs:
         raise ValueError("Sample id is required for this entrypoint")
     sample_id = kwargs["sample_id"]

--- a/frontend/app/models.py
+++ b/frontend/app/models.py
@@ -23,6 +23,13 @@ class SampleBasketObject(RWModel):  # pylint: disable=too-few-public-methods
     analysis_profile: str
 
 
+class QualityControlResult(Enum):
+    """QC statuses"""
+
+    PASSED = "passed"
+    FAILED = "failed"
+
+
 class BadSampleQualityAction(Enum):
     """Actions that could be taken if a sample have low quality."""
 

--- a/frontend/app/models.py
+++ b/frontend/app/models.py
@@ -28,6 +28,7 @@ class QualityControlResult(Enum):
 
     PASSED = "passed"
     FAILED = "failed"
+    UNPROCESSED = "unprocessed"
 
 
 class BadSampleQualityAction(Enum):


### PR DESCRIPTION
This update adds a dropdown menu to /groups allowing users to toggle QC status for multiple samples. 

![bonsai-qc-pr](https://github.com/Clinical-Genomics-Lund/bonsai/assets/13668555/6dcbe17a-efb1-4e12-ae9b-4e1abcb41ffe)

The QC form is submitted to new route `groups.qc_status` which updates the QC status for the selected samples and redirects back to `/groups`. 

The sample selection in the sample JS table is retained on page reload through `GET` args. This is implemented with the assumption that the end-user won't try to set the QC status for so many samples at the same time that the `GET` request grows too long.

Other changes:
* Added route `groups.qc_status`
* Added Enum for QC statuses
* Added option to /groups view to render the page with pre-selected samples in the JS table using `GET` args.
* Changed whitespace control to jinja to trim whitespace left behind by in-line template code 

Closes #97 

### Suggested test sequence:

1. Setup new bonsai instance from this branch and throw a few samples at it
2. Go to /groups and verify that the QC button is disabled
3. Select a few samples and verify that the QC controls can be accessed
4. Setting QC to passed results in a page reload and a change in the QC status of the samples
5. Setting QC to failed results in a page reload and a change in the QC status of the samples. The correct follow-up action and comment is added to the affected samples. 

### TODO:

- [ ] Review current changes
- [ ] Update CHANGELOG
- [ ] Make QC dropdown menu wider
- [ ] Organize new JS code better in new templates?
- [x] Fix merge conflicts