### PR TITLE
Release 0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ### Added
 
+### Fixed
+
+### Changed
+
+## [v0.2.0]
+
+### Added
+
  - Improved output of create_user API CLI command
  - bonsai_api create-user command have options for mail, first name and last name.
  - Open samples by clicking on labels in the similar samples card in the samples view.

--- a/api/app/__version__.py
+++ b/api/app/__version__.py
@@ -1,3 +1,3 @@
 """API version"""
 
-VERSION = "0.1.0"
+VERSION = "0.2.0"

--- a/frontend/app/__version__.py
+++ b/frontend/app/__version__.py
@@ -1,2 +1,2 @@
 """Bonsai frontend version."""
-VERSION = "0.1.0"
+VERSION = "0.2.0"


### PR DESCRIPTION
This release is only compatible with Jasen v0.4.0

### Added

 - Improved output of create_user API CLI command
 - bonsai_api create-user command have options for mail, first name and last name.
 - Open samples by clicking on labels in the similar samples card in the samples view.
 - Optional "extended" HTTP argument to sample view to view extended prediction info

### Fixed

 - Fixed crash in create_user API CLI command
 - Resistance_report now render work in progress page
 - Removed old project name from GrapeTree header
 - Fixed issue that prevented node labels in GrapeTree from being displayed.

### Changed

 - The role "user" have permission to comment and classify QC
 - Updated PRP to version 0.3.0