### PR TITLE
Freeze uvicorn to v0.25.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@
 ### Changed
 
  - Display the sum of kraken assigned reads and added reads in spp card by default.
+ - Froze uvicorn to version 0.25.0
+ - Updated fastapi to version 0.108.0
 
 ## [v0.2.0]
 

--- a/api/setup.cfg
+++ b/api/setup.cfg
@@ -20,9 +20,9 @@ python_requires = >=3.10
 install_requires =
     setuptools
     wheel
-    uvicorn[standard]
+    uvicorn[standard]==0.25.0
     click==8.1.7
-    fastapi[all]==0.104.1
+    fastapi[all]==0.108.0
     python-jose[cryptography]==3.3.0
     python-multipart==0.0.6
     passlib==1.7.4


### PR DESCRIPTION
This PR reverts the changed behavior of running Bonsai behind a proxy by temporarily freezing uvicorn to version 0.25.0 until fastapi is updated to handle the change.

close #139 