### PR TITLE
Release v0.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ### Added
 
+### Fixed
+
+### Changed
+
+## [v0.2.1]
+
+### Added
+
  - Bulk QC status dropdown in group view
 
 ### Fixed

--- a/api/app/__version__.py
+++ b/api/app/__version__.py
@@ -1,3 +1,3 @@
 """API version"""
 
-VERSION = "0.2.0"
+VERSION = "0.2.1"

--- a/frontend/app/__version__.py
+++ b/frontend/app/__version__.py
@@ -1,2 +1,2 @@
 """Bonsai frontend version."""
-VERSION = "0.2.0"
+VERSION = "0.2.1"


### PR DESCRIPTION
This is a PR for a patch release

## Changes

### Added

 - Bulk QC status dropdown in group view

### Fixed

 - Fixed crash when clustering on samples without a MLST profile
 - Fixed bug that prevented adding samples to the basket in groups without "analysis profile" column
 - Fixed issue that prevented finding similar samples in group view

### Changed

 - Display the sum of kraken assigned reads and added reads in spp card by default.
 - Froze uvicorn to version 0.25.0
 - Updated fastapi to version 0.108.0
