### PR TITLE
Add button for deleting samples + some fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### Added
 
  - Bulk QC status dropdown in group view
+ - Add button to remove samples from the group- and groups view.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@
  - Fixed crash when clustering on samples without a MLST profile
  - Fixed bug that prevented adding samples to the basket in groups without "analysis profile" column
  - Fixed issue that prevented finding similar samples in group view
+ - 500 error when trying to get a sample removed from the database
+ - Frontend properly handles non-existing samples and group
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,12 @@
 
 ### Added
 
+ - Add button to remove samples from the group- and groups view.
+
 ### Fixed
+
+ - 500 error when trying to get a sample removed from the database
+ - Frontend properly handles non-existing samples and group
 
 ### Changed
 
@@ -11,15 +16,12 @@
 ### Added
 
  - Bulk QC status dropdown in group view
- - Add button to remove samples from the group- and groups view.
 
 ### Fixed
 
  - Fixed crash when clustering on samples without a MLST profile
  - Fixed bug that prevented adding samples to the basket in groups without "analysis profile" column
  - Fixed issue that prevented finding similar samples in group view
- - 500 error when trying to get a sample removed from the database
- - Frontend properly handles non-existing samples and group
 
 ### Changed
 

--- a/api/app/crud/sample.py
+++ b/api/app/crud/sample.py
@@ -234,13 +234,13 @@ async def delete_samples(db: Database, sample_ids: List[str]) -> bool:
         job_ids = []
         for sample_id in sample_ids:
             submitted_job = schedule_remove_genome_signature(sample_id)
-            job_ids.append(submitted_job.job_id)
+            job_ids.append(submitted_job.id)
         result["remove_signature_jobs"] = job_ids
         # remove reindex
         index_job = schedule_remove_genome_signature_from_index(
             sample_ids, depends_on=job_ids
         )
-        result["update_index_job"] = index_job.job_id
+        result["update_index_job"] = index_job.id
     return result
 
 

--- a/api/app/crud/sample.py
+++ b/api/app/crud/sample.py
@@ -192,39 +192,31 @@ async def update_sample(db: Database, updated_data: SampleInCreate) -> bool:
 async def delete_sample(db: Database, sample_id: str) -> bool:
     """Delete a sample from the database, remove it from groups, and remove its signature."""
 
-    async with db.client.start_session() as session:
-        async with session.start_transaction():
-            # remove sample from database
-            resp_rm_sample = await db.sample_collection.delete_one(
-                {"sample_id": sample_id}, session=session
-            )
-            # verify that only one sample found and one document was modified
-            sample_is_deleted = (
-                resp_rm_sample.matched_count == 1 and resp_rm_sample.deleted_count == 1
-            )
-            LOG.info("Removing sample: %s; status: %s", sample_id, sample_is_deleted)
+    # remove sample from database
+    resp = await db.sample_collection.delete_one({"sample_id": sample_id})
+    # verify that only one sample found and one document was modified
+    sample_is_deleted = resp.matched_count == 1 and resp.deleted_count == 1
+    LOG.info("Removing sample: %s; status: %s", sample_id, sample_is_deleted)
 
-            # remove sample from group
-            resp_rm_group = await db.sample_group_collection.updateMany(
-                {"included_samples": {"$in": [sample_id]}},  # filter
-                {
-                    "$pull": {
-                        "included_samples": {"$in": [sample_id]}
-                    },  # remove samples from group
-                    "$set": {"modified_at": datetime.now()},  # update modified at
-                },
-                session=session,
-            )
-            # verify that number of modified groups and samples match
-            sample_is_removed_from_group = (
-                resp_rm_group.matched_count == resp_rm_group.modified_count
-            )
-            LOG.info(
-                "Removing sample %s from groups; in n groups: %d; n modified documents: %d",
-                sample_id,
-                resp_rm_group.matched_count,
-                resp_rm_group.modified_count,
-            )
+    # remove sample from group if sample was deleted
+    if sample_is_deleted:
+        resp = await db.sample_group_collection.updateMany(
+            {"included_samples": {"$in": [sample_id]}},  # filter
+            {
+                "$pull": {
+                    "included_samples": {"$in": [sample_id]}
+                },  # remove samples from group
+                "$set": {"modified_at": datetime.now()},  # update modified at
+            },
+        )
+        # verify that number of modified groups and samples match
+        sample_is_removed_from_group = resp.matched_count == resp.modified_count
+        LOG.info(
+            "Removing sample %s from groups; in n groups: %d; n modified documents: %d",
+            sample_id,
+            resp.matched_count,
+            resp.modified_count,
+        )
 
     # remove signature from database
     if sample_is_deleted and sample_is_removed_from_group:

--- a/api/app/redis/minhash.py
+++ b/api/app/redis/minhash.py
@@ -21,6 +21,14 @@ def schedule_add_genome_signature(sample_id: str, signature) -> SubmittedJob | s
     return SubmittedJob(id=job.id, task=task)
 
 
+def schedule_remove_genome_signature(sample_id: str) -> SubmittedJob | str:
+    """Schedule adding signature to index."""
+    task = "minhash_service.tasks.remove_signature"
+    job = redis.minhash.enqueue(task, sample_id=sample_id, job_timeout="30m")
+    LOG.debug("Submitting job, %s to %s", task, job.worker_name)
+    return SubmittedJob(id=job.id, task=task)
+
+
 def schedule_add_genome_signature_to_index(
     sample_ids: List[str], depends_on: List[str] = None, **enqueue_kwargs
 ) -> SubmittedJob:

--- a/api/app/redis/minhash.py
+++ b/api/app/redis/minhash.py
@@ -37,7 +37,36 @@ def schedule_add_genome_signature_to_index(
 
     The job can depend on the completion of previous jobs by providing a job_id
     """
-    task = "minhash_service.tasks.index"
+    task = "minhash_service.tasks.add_to_index"
+    submit_kwargs = {
+        "retry": Retry(max=3, interval=60),
+        **enqueue_kwargs,
+    }  # default retry 3 times, 60 in between
+    # make job depend on the job of others
+    if depends_on is not None:
+        submit_kwargs["depends_on"] = Dependency(
+            jobs=depends_on,
+            allow_failure=False,  # allow if dependent job fails
+            enqueue_at_front=True,  # put dependents at front of queue
+        )
+
+    # submit job
+    job = redis.minhash.enqueue(
+        task, sample_ids=sample_ids, job_timeout="30m", **submit_kwargs
+    )
+    LOG.debug("Submitting job, %s to %s", task, job.worker_name)
+    return SubmittedJob(id=job.id, task=task)
+
+
+def schedule_remove_genome_signature_from_index(
+    sample_ids: List[str], depends_on: List[str] = None, **enqueue_kwargs
+) -> SubmittedJob:
+    """
+    Schedule removing signature from index.
+
+    The job can depend on the completion of previous jobs by providing a job_id
+    """
+    task = "minhash_service.tasks.remove_from_index"
     submit_kwargs = {
         "retry": Retry(max=3, interval=60),
         **enqueue_kwargs,

--- a/api/app/routers/samples.py
+++ b/api/app/routers/samples.py
@@ -239,13 +239,13 @@ async def delete_sample(
     ),
 ):
     try:
-        await delete_sample_from_db(db, sample_id)
+        result = await delete_sample_from_db(db, sample_id)
     except EntryNotFound as error:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
-            detail=error,
+            detail=str(error),
         ) from error
-    return {"sample_id": sample_id}
+    return result
 
 
 @router.post("/samples/{sample_id}/signature", tags=DEFAULT_TAGS)

--- a/api/app/routers/samples.py
+++ b/api/app/routers/samples.py
@@ -205,7 +205,7 @@ async def read_sample(
     except EntryNotFound as error:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
-            detail=error,
+            detail=str(error),
         ) from error
     return sample_obj
 
@@ -355,7 +355,7 @@ async def update_qc_status(
     except EntryNotFound as error:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
-            detail=error,
+            detail=str(error),
         ) from error
     return status_obj
 

--- a/api/app/routers/samples.py
+++ b/api/app/routers/samples.py
@@ -10,6 +10,7 @@ from pymongo.errors import DuplicateKeyError
 
 from ..crud.sample import EntryNotFound, add_comment, add_location
 from ..crud.sample import create_sample as create_sample_record
+from ..crud.sample import delete_sample as delete_sample_from_db
 from ..crud.sample import get_sample, get_samples_summary
 from ..crud.sample import hide_comment as hide_comment_for_sample
 from ..crud.sample import update_sample as crud_update_sample
@@ -220,6 +221,31 @@ async def update_sample(
     :rtype: Dict[str, str | SampleInDatabase]
     """
     return {"sample_id": sample_id, "sample": sample, "location": location}
+
+
+@router.delete(
+    "/samples/{sample_id}", status_code=status.HTTP_200_OK, tags=DEFAULT_TAGS
+)
+async def delete_sample(
+    sample_id: str = Path(
+        ...,
+        title="ID of the sample to get",
+        min_length=3,
+        max_length=100,
+        regex=SAMPLE_ID_PATTERN,
+    ),
+    current_user: UserOutputDatabase = Security(  # pylint: disable=unused-argument
+        get_current_active_user, scopes=[UPDATE_PERMISSION]
+    ),
+):
+    try:
+        await delete_sample_from_db(db, sample_id)
+    except EntryNotFound as error:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=error,
+        ) from error
+    return {"sample_id": sample_id}
 
 
 @router.post("/samples/{sample_id}/signature", tags=DEFAULT_TAGS)

--- a/frontend/app/blueprints/api/views.py
+++ b/frontend/app/blueprints/api/views.py
@@ -2,12 +2,15 @@
 import json
 
 import requests
+from app.bonsai import (
+    TokenObject,
+    add_samples_to_basket,
+    get_samples_by_id,
+    remove_samples_from_basket,
+)
+from app.models import SampleBasketObject
 from flask import Blueprint, flash, jsonify, request
 from flask_login import current_user, login_required
-
-from app.bonsai import TokenObject, add_samples_to_basket, remove_samples_from_basket
-from app.models import SampleBasketObject
-from app.bonsai import get_samples_by_id
 
 api_bp = Blueprint("api", __name__, template_folder="templates", static_folder="static")
 
@@ -38,9 +41,11 @@ def add_sample_to_basket():
     # store sample informaiton in required format
     samples_to_add = []
     for sample in response["records"]:
-        samples_to_add.append(SampleBasketObject(
-            sample_id=sample['sample_id'], analysis_profile=sample["profile"]
-        ))
+        samples_to_add.append(
+            SampleBasketObject(
+                sample_id=sample["sample_id"], analysis_profile=sample["profile"]
+            )
+        )
 
     try:
         add_samples_to_basket(token, samples=samples_to_add)

--- a/frontend/app/blueprints/cluster/views.py
+++ b/frontend/app/blueprints/cluster/views.py
@@ -4,12 +4,11 @@ import logging
 from enum import Enum
 from typing import Any, Dict
 
+from app.bonsai import TokenObject, cluster_samples, get_samples_by_id
 from flask import Blueprint, flash, redirect, render_template, request, url_for
 from flask_login import current_user, login_required
 from pydantic import BaseModel
 from requests.exceptions import HTTPError
-
-from app.bonsai import TokenObject, cluster_samples, get_samples_by_id
 
 LOG = logging.getLogger(__name__)
 
@@ -91,7 +90,7 @@ def gather_metadata(samples) -> MetaData:
         sample_id = sample["sample_id"]
         metadata[sample_id] = {"time": sample["created_at"]}
         if "mlst" in sample:
-            metadata[sample_id]['MLST ST'] = get_value(sample['mlst'], 'sequence_type')
+            metadata[sample_id]["MLST ST"] = get_value(sample["mlst"], "sequence_type")
     # build metadata list
     metadata_list = set()
     for meta in metadata.values():

--- a/frontend/app/blueprints/comparison/views.py
+++ b/frontend/app/blueprints/comparison/views.py
@@ -1,9 +1,8 @@
 """Views for comparing multiple samples."""
 
+from app.bonsai import TokenObject, get_samples_by_id
 from flask import Blueprint, redirect, render_template, session, url_for
 from flask_login import current_user, login_required
-
-from app.bonsai import TokenObject, get_samples_by_id
 
 comparison_bp = Blueprint(
     "comparison",

--- a/frontend/app/blueprints/groups/templates/group.html
+++ b/frontend/app/blueprints/groups/templates/group.html
@@ -1,6 +1,6 @@
 {% extends "layout.html" %}
 {% import "cell_fmt.html" as cell_format %}
-{% from "shared.html" import search_similar_btn, search_similar_js, add_to_basket_btn, add_to_basket_js, qc_bulk_toggle %}
+{% from "shared.html" import search_similar_btn, search_similar_js, add_to_basket_btn, add_to_basket_js, qc_bulk_toggle, delete_samples_btn %}
 
 {% block css %}
     {{ super() }}
@@ -27,6 +27,9 @@
                     <span id="n-selected-samples-counter">0</span>
                 </span>
                 {{ add_to_basket_btn() }}
+                {% if current_user.is_admin %}
+                    {{ delete_samples_btn() }}
+                {% endif %}
                 {{ search_similar_btn() }}
                 {{ qc_bulk_toggle(bad_qc_actions)}}
                 <form id="sampleForm" class="execute-form" method="POST" action="{{ url_for('cluster.tree') }}">
@@ -101,6 +104,10 @@
                 document.getElementById("add-to-basket-btn").disabled = 1 > this.getSelection().length
                 document.getElementById("toggle-qc-btn").disabled = 1 > this.getSelection().length
                 document.getElementById("n-selected-samples-counter").innerText = this.getSelection().length
+                // enable remove samples btn
+                if (document.getElementById("remove-samples-btn") !== null) {
+                  document.getElementById("remove-samples-btn").disabled = 0 > this.getSelection().length
+                }
                 // update selected samples counter
                 sessionStorage.setItem("selectedSamples", JSON.stringify(this.getSelection()));
                 // enable find simiar samples button when ONE row is selected

--- a/frontend/app/blueprints/groups/templates/group.html
+++ b/frontend/app/blueprints/groups/templates/group.html
@@ -61,7 +61,7 @@
     w2utils.formatters['tags']  = formatTag
         const baseUrl = {{ request.script_root|tojson }}
         let element = document.createElement('a')
-        let path = data.groupId ? `samples/${val}?group_id=${data.groupId}` : `samples/${val}`
+        let path = data.groupId ? `sample/${val}?group_id=${data.groupId}` : `sample/${val}`
         element.setAttribute('href', `${baseUrl}/${path}`)
         element.classList.add('br-link')
         element.innerText = val

--- a/frontend/app/blueprints/groups/templates/groups.html
+++ b/frontend/app/blueprints/groups/templates/groups.html
@@ -1,5 +1,5 @@
 {% extends "layout.html" %}
-{% from "shared.html" import search_similar_btn, search_similar_js, add_to_basket_btn, add_to_basket_js, qc_bulk_toggle %}
+{% from "shared.html" import search_similar_btn, search_similar_js, add_to_basket_btn, add_to_basket_js, qc_bulk_toggle, delete_samples_btn %}
 
 {% block css %}
 {{ super() }}
@@ -33,23 +33,7 @@
                 </span>
                 {{ add_to_basket_btn() }}
                 {% if current_user.is_admin %}
-                    <form id="remove-samples-form" method=POST action={{ url_for("samples.remove_samples") }}>
-                        <input type="text" name="sample-ids" hidden>
-                        <button id="remove-samples-btn" class="btn btn-sm btn-outline-danger ms-1" 
-                                type="submit" disabled>
-                            <i class="bi bi-trash"></i>
-                            <span>Remove samples</span>
-                        </button>
-                    </form>
-                    <script>
-                      const removeSamplesForm = document.getElementById("remove-samples-form")
-                      removeSamplesForm.addEventListener("submit", event => {
-                        event.preventDefault()
-                        // add selected samples to form
-                        event.target.querySelector("input").value = JSON.stringify(window.getSelectedRows())
-                        removeSamplesForm.submit()
-                      })
-                    </script>
+                    {{ delete_samples_btn() }}
                 {% endif %}
                 {{ search_similar_btn() }}
                 {% if current_user.is_admin %}

--- a/frontend/app/blueprints/groups/templates/groups.html
+++ b/frontend/app/blueprints/groups/templates/groups.html
@@ -32,6 +32,25 @@
                     <span id="n-selected-samples-counter">0</span>
                 </span>
                 {{ add_to_basket_btn() }}
+                {% if current_user.is_admin %}
+                    <form id="remove-samples-form" method=POST action={{ url_for("samples.remove_samples") }}>
+                        <input type="text" name="sample-ids" hidden>
+                        <button id="remove-samples-btn" class="btn btn-sm btn-outline-danger ms-1" 
+                                type="submit" disabled>
+                            <i class="bi bi-trash"></i>
+                            <span>Remove samples</span>
+                        </button>
+                    </form>
+                    <script>
+                      const removeSamplesForm = document.getElementById("remove-samples-form")
+                      removeSamplesForm.addEventListener("submit", event => {
+                        event.preventDefault()
+                        // add selected samples to form
+                        event.target.querySelector("input").value = JSON.stringify(window.getSelectedRows())
+                        removeSamplesForm.submit()
+                      })
+                    </script>
+                {% endif %}
                 {{ search_similar_btn() }}
                 {% if current_user.is_admin %}
                     <a href={{ url_for('groups.edit_groups') }} class="btn btn-sm btn-secondary ms-2">
@@ -55,7 +74,7 @@
     w2utils.formatters['sampleid']  = (val, data) => {
         const baseUrl = {{ request.script_root|tojson }}
         let element = document.createElement('a')
-        let path = data.groupId ? `samples/${val}?group_id=${data.groupId}` : `samples/${val}`
+        let path = data.groupId ? `sample/${val}?group_id=${data.groupId}` : `sample/${val}`
         element.setAttribute('href', `${baseUrl}/${path}`)
         element.classList.add('br-link')
         element.innerText = val
@@ -88,6 +107,10 @@
                 document.getElementById("toggle-qc-btn").disabled = 1 > this.getSelection().length
                 // enable find simiar samples button when ONE row is selected
                 document.getElementById("select-similar-samples-btn").disabled = 1 !== this.getSelection().length
+                // enable remove samples btn
+                if (document.getElementById("remove-samples-btn") !== null) {
+                  document.getElementById("remove-samples-btn").disabled = 0 > this.getSelection().length
+                }
                 // update selected samples counter
                 document.getElementById("n-selected-samples-counter").innerText = this.getSelection().length
                 sessionStorage.setItem(
@@ -123,6 +146,24 @@
     }
     grid.render()
     refreshGrid(true)
+</script>
+<script>
+    function removeSelectedSamples(btn) {
+        // add selected samples from table to session storage
+        const body = {
+            selectedSamples: JSON.parse(sessionStorage.getItem("selectedSamples"))
+        }
+        const baseUrl = {{ request.script_root|tojson }}
+        fetch(`${baseUrl}/api/basket/add`, {
+            method: "POST",
+            body: JSON.stringify(body),
+            headers: {
+                'Accept': 'application/json', 
+                'Content-Type': 'application/json' 
+            },
+            credentials: 'same-origin'
+        }).then(response => {location.reload()})
+    }
 </script>
 <script>
     const apiURL = "{{ config.BONSAI_API_URL }}"

--- a/frontend/app/blueprints/groups/templates/shared.html
+++ b/frontend/app/blueprints/groups/templates/shared.html
@@ -193,3 +193,23 @@ document.getElementById("similar-samples-threshold").addEventListener("input", (
      }
     </script>
 {% endmacro %}
+
+{% macro delete_samples_btn() %}
+    <form id="remove-samples-form" method=POST action={{ url_for("samples.remove_samples") }}>
+        <input type="text" name="sample-ids" hidden>
+        <button id="remove-samples-btn" class="btn btn-sm btn-outline-danger ms-1" 
+                type="submit" disabled>
+            <i class="bi bi-trash"></i>
+            <span>Delete samples</span>
+        </button>
+    </form>
+    <script>
+        const removeSamplesForm = document.getElementById("remove-samples-form")
+        removeSamplesForm.addEventListener("submit", event => {
+        event.preventDefault()
+        // add selected samples to form
+        event.target.querySelector("input").value = JSON.stringify(window.getSelectedRows())
+        removeSamplesForm.submit()
+        })
+    </script>
+{% endmacro %}

--- a/frontend/app/blueprints/groups/templates/shared.html
+++ b/frontend/app/blueprints/groups/templates/shared.html
@@ -1,7 +1,7 @@
 {% from  'sidebar.html' import qc_classification_form_fields, qc_form_controls_js  %}
 
 {% macro add_to_basket_btn() %}
-<button id="add-to-basket-btn" class="btn btn-sm btn-outline-success ms-4" 
+<button id="add-to-basket-btn" class="btn btn-sm btn-outline-success ms-2" 
         onclick="addSelectedSamplesToBasket(this)" disabled>
     <i class="bi bi-plus-lg"></i>
     <span>Add to basket</span>

--- a/frontend/app/blueprints/login/views.py
+++ b/frontend/app/blueprints/login/views.py
@@ -1,6 +1,9 @@
 """Manage user authentication."""
 import logging
 
+from app import __version__ as VERSION
+from app.bonsai import TokenObject, get_auth_token, get_current_user
+from app.extensions import login_manager
 from flask import (
     Blueprint,
     Response,
@@ -13,10 +16,6 @@ from flask import (
 )
 from flask_login import UserMixin, login_required, login_user, logout_user
 from requests.exceptions import HTTPError
-
-from app import __version__ as VERSION
-from app.bonsai import TokenObject, get_auth_token, get_current_user
-from app.extensions import login_manager
 
 LOG = logging.getLogger(__name__)
 

--- a/frontend/app/blueprints/public/views.py
+++ b/frontend/app/blueprints/public/views.py
@@ -1,7 +1,6 @@
 """Public accessable assets and views."""
-from flask import Blueprint, render_template, request, send_from_directory
-
 from app import __version__ as VERSION
+from flask import Blueprint, render_template, request, send_from_directory
 
 public_bp = Blueprint(
     "public",

--- a/frontend/app/blueprints/sample/views.py
+++ b/frontend/app/blueprints/sample/views.py
@@ -55,7 +55,12 @@ def remove_samples():
 
         sample_ids = json.loads(request.form.get("sample-ids", "[]"))
         if len(sample_ids) > 0:
-            delete_samples(token, sample_ids=sample_ids)
+            result = delete_samples(token, sample_ids=sample_ids)
+            current_app.logger.info(
+                "removed %d samples, removed from %d groups",
+                result["n_deleted"],
+                result["removed_from_n_groups"],
+            )
     else:
         flash("You dont have permission to remove samples", "warning")
     return redirect(request.referrer)

--- a/frontend/app/blueprints/sample/views.py
+++ b/frontend/app/blueprints/sample/views.py
@@ -55,7 +55,7 @@ def remove_samples():
 
         sample_ids = json.loads(request.form.get("sample-ids", "[]"))
         if len(sample_ids) > 0:
-            delete_samples(token, sample_id=sample_ids)
+            delete_samples(token, sample_ids=sample_ids)
     else:
         flash("You dont have permission to remove samples", "warning")
     return redirect(request.referrer)

--- a/frontend/app/blueprints/sample/views.py
+++ b/frontend/app/blueprints/sample/views.py
@@ -1,5 +1,6 @@
 """Declaration of views for samples"""
 from typing import Any, Dict, Tuple
+import json
 
 from flask import (
     Blueprint,
@@ -24,6 +25,7 @@ from app.bonsai import (
     remove_comment_from_sample,
     update_sample_qc_classification,
 )
+from app.bonsai import delete_samples
 from app.models import BadSampleQualityAction, QualityControlResult
 
 from .controllers import create_amr_summary
@@ -44,7 +46,34 @@ def samples():
     return render_template("samples.html")
 
 
-@samples_bp.route("/samples/<sample_id>")
+@samples_bp.route("/samples/remove", methods=["POST"])
+@login_required
+def remove_samples():
+    """Remove samples."""
+    if current_user.is_admin:
+        token = TokenObject(**current_user.get_id())
+
+        sample_ids = json.loads(request.form.get("sample-ids", "[]"))
+        if len(sample_ids) > 0:
+            delete_samples(token, sample_id=sample_ids)
+    else:
+        flash("You dont have permission to remove samples", "warning")
+    return redirect(request.referrer)
+
+
+@samples_bp.route("/samples/cluster/", methods=["GET", "POST"])
+@login_required
+def cluster(sample_id: str) -> str:
+    """Samples view."""
+    token = TokenObject(**current_user.get_id())
+
+    if request.method == "POST":
+        samples_info = request.body["samples"]
+        cgmlst_cluster_samples(token, samples=samples_info)
+    return render_template("sample.html", sample_id=sample_id)
+
+
+@samples_bp.route("/sample/<sample_id>")
 @login_required
 def sample(sample_id: str) -> str:
     """Generate sample page.
@@ -109,7 +138,7 @@ def sample(sample_id: str) -> str:
     )
 
 
-@samples_bp.route("/samples/<sample_id>/similar", methods=["POST"])
+@samples_bp.route("/sample/<sample_id>/similar", methods=["POST"])
 @login_required
 def find_similar_samples(sample_id: str) -> Tuple[Dict[str, Any], int]:
     """Find samples that are similar."""
@@ -125,7 +154,7 @@ def find_similar_samples(sample_id: str) -> Tuple[Dict[str, Any], int]:
     return resp.model_dump(), 200
 
 
-@samples_bp.route("/samples/<sample_id>/comment", methods=["POST"])
+@samples_bp.route("/sample/<sample_id>/comment", methods=["POST"])
 @login_required
 def add_comment(sample_id: str) -> str:
     """Post sample."""
@@ -141,7 +170,7 @@ def add_comment(sample_id: str) -> str:
     return redirect(url_for("samples.sample", sample_id=sample_id))
 
 
-@samples_bp.route("/samples/<sample_id>/comment/<comment_id>", methods=["POST"])
+@samples_bp.route("/sample/<sample_id>/comment/<comment_id>", methods=["POST"])
 @login_required
 def hide_comment(sample_id: str, comment_id: str) -> str:
     """Hist comment for sample."""
@@ -154,7 +183,7 @@ def hide_comment(sample_id: str, comment_id: str) -> str:
     return redirect(url_for("samples.sample", sample_id=sample_id))
 
 
-@samples_bp.route("/samples/<sample_id>/qc_status", methods=["POST"])
+@samples_bp.route("/sample/<sample_id>/qc_status", methods=["POST"])
 @login_required
 def update_qc_classification(sample_id: str) -> str:
     """Update the quality control report of a sample."""
@@ -180,7 +209,7 @@ def update_qc_classification(sample_id: str) -> str:
     return redirect(url_for("samples.sample", sample_id=sample_id))
 
 
-@samples_bp.route("/samples/<sample_id>/resistance_report")
+@samples_bp.route("/sample/<sample_id>/resistance_report")
 @login_required
 def resistance_report(sample_id: str) -> str:
     """Samples view."""
@@ -189,15 +218,3 @@ def resistance_report(sample_id: str) -> str:
     return render_template(
         "resistance_report.html", title=f"{sample_id} resistance", sample=sample_info
     )
-
-
-@samples_bp.route("/cluster/", methods=["GET", "POST"])
-@login_required
-def cluster(sample_id: str) -> str:
-    """Samples view."""
-    token = TokenObject(**current_user.get_id())
-
-    if request.method == "POST":
-        samples_info = request.body["samples"]
-        cgmlst_cluster_samples(token, samples=samples_info)
-    return render_template("sample.html", sample_id=sample_id)

--- a/frontend/app/bonsai.py
+++ b/frontend/app/bonsai.py
@@ -194,6 +194,16 @@ def get_samples(headers: CaseInsensitiveDict, **kwargs):
 
 
 @api_authentication
+def delete_samples(headers: CaseInsensitiveDict, sample_ids: List[str]):
+    """Remove samples from database."""
+    # conduct query
+    url = f'{current_app.config["BONSAI_API_URL"]}/samples/'
+    resp = requests.delete(url, headers=headers, json=sample_ids, timeout=TIMEOUT)
+
+    resp.raise_for_status()
+    return resp.json()
+
+@api_authentication
 def get_samples_by_id(headers: CaseInsensitiveDict, **kwargs):
     """Search the database for multiple samples"""
     # conduct query

--- a/frontend/app/bonsai.py
+++ b/frontend/app/bonsai.py
@@ -203,6 +203,7 @@ def delete_samples(headers: CaseInsensitiveDict, sample_ids: List[str]):
     resp.raise_for_status()
     return resp.json()
 
+
 @api_authentication
 def get_samples_by_id(headers: CaseInsensitiveDict, **kwargs):
     """Search the database for multiple samples"""

--- a/minhash_service/minhash_service/tasks.py
+++ b/minhash_service/minhash_service/tasks.py
@@ -3,9 +3,9 @@ import logging
 from typing import Dict, List
 
 from .minhash.cluster import ClusterMethod, cluster_signatures
-from .minhash.io import add_signatures_to_index, remove_signatures_from_index
+from .minhash.io import add_signatures_to_index
 from .minhash.io import remove_signature as remove_signature_file
-from .minhash.io import write_signature
+from .minhash.io import remove_signatures_from_index, write_signature
 from .minhash.similarity import SimilarSignatures, get_similar_signatures
 
 LOG = logging.getLogger(__name__)

--- a/minhash_service/minhash_service/tasks.py
+++ b/minhash_service/minhash_service/tasks.py
@@ -3,7 +3,7 @@ import logging
 from typing import Dict, List
 
 from .minhash.cluster import ClusterMethod, cluster_signatures
-from .minhash.io import add_signatures_to_index
+from .minhash.io import add_signatures_to_index, remove_signatures_from_index
 from .minhash.io import remove_signature as remove_signature_file
 from .minhash.io import write_signature
 from .minhash.similarity import SimilarSignatures, get_similar_signatures
@@ -38,7 +38,7 @@ def remove_signature(sample_id: str) -> Dict[str, str | bool]:
     return {"sample_id": sample_id, "removed": status}
 
 
-def index(sample_ids: List[str]) -> str:
+def add_to_index(sample_ids: List[str]) -> str:
     """
     Add signatures to sourmash SBT index.
 
@@ -54,6 +54,25 @@ def index(sample_ids: List[str]) -> str:
         msg = f"Appended {signatures}"
     else:
         msg = f"Failed to append signatures, {signatures}"
+    return msg
+
+
+def remove_from_index(sample_ids: List[str]) -> str:
+    """
+    Remove signatures from sourmash SBT index.
+
+    :param sample_ids List[str]: Sample ids of signatures to remove
+
+    :return: result message
+    :rtype: str
+    """
+    LOG.info("Indexing signatures...")
+    res = remove_signatures_from_index(sample_ids)
+    signatures = ", ".join(list(sample_ids))
+    if res:
+        msg = f"Removed {signatures}"
+    else:
+        msg = f"Failed to remove signatures, {signatures}"
     return msg
 
 


### PR DESCRIPTION
This PR adds a button to the groups and group view for removing the selected samples. Only admin users can perform this operation.

When a user clicks the button it will call the `/samples` entry point on the API with the DELETE method. This removes the sample from the database, removes the samples from any groups it have been added to, and triggers jobs on the minhash service to remove the signature file and strip the samples from the index.

This PR also display the a 404 page when trying to access a non existing group or sample.

Close #137 

### How to setup and perform the tests

1. Setup a Bonsai instance.
2. Load a few samples to the database and add them to groups
3. Try to remove the samples from the `/groups` and `/groups/<group_name>` views.

### Expected outcome 

1. The samples should be removed
2. The sample id should be removed from "included samples" and the last modified field should be updated.
3. The signature should be removed ( check minhash_service mounted volume )
