### PR TITLE
Fix #144 "Argument too long" from curl

### DIFF
--- a/scripts/upload_sample.sh
+++ b/scripts/upload_sample.sh
@@ -87,7 +87,7 @@ status=$(curl -X 'POST' -s            \
   -H 'Content-Type: application/json' \
   -w %{http_code}                     \
   -o "${RESPONSE}"                    \
-  -d "${sample}")
+  -d @${input_file})
 
 # check upload status
 check_curl_status $status


### PR DESCRIPTION
This fix fixes bug #144 , by only pointing to a file path in the `curl` command, rather than outputting the full JSON content, which apparently can make the command too long for large files. 

### Expected outcome 

See #144 for how to reproduce the bug, as well as reproduce the correct behavior, which is that the upload now works also for large files, with this fix.