### PR TITLE
Fix default compose file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,11 @@
  - 500 error when trying to get a sample removed from the database
  - Frontend properly handles non-existing samples and group
  - Fixed typo in similar samples card that caused invalid URLs
+ - Fixed default fontend config to work with default docker-compose file
 
 ### Changed
+
+ - Changed default app port to 8000 and api port to 8001
 
 ## [v0.2.1]
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,7 +30,7 @@ services:
       - minhash_service
       - allele_cluster_service
     ports: 
-      - "8011:8000"
+      - "8001:8000"
     environment:
       - ALLOWED_ORIGINS=*
     volumes:
@@ -48,7 +48,7 @@ services:
       - mongodb
       - api
     ports: 
-      - "8010:5000"
+      - "8000:5000"
     environment:
       - FLASK_APP=app.app:create_app
       - FLASK_ENV=development 

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -10,9 +10,9 @@ To install Bonsai, first clone the repository and start the softwares.
 .. code-block:: bash
 
    # clone Bonsai
-   git clone git@github.com:Clinical-Genomics-Lund/cgviz.git
+   git clone git@github.com:Clinical-Genomics-Lund/bonsai.git
    # navigate to project directory
-   cd cgviz
+   cd bonsai
    # start the bonsai software stack
    docker-compose up -d
 
@@ -26,7 +26,12 @@ Create an admin user with the CLI. There are three built in user roles (*user*, 
 
 .. code-block:: bash
 
-   docker-compose exec api bonsai_api create-user -u admin -p admin -r admin
+   docker-compose exec api bonsai_api create-user -u admin                 \
+                                                  -p admin                 \
+                                                  --fname Place            \
+                                                  --lname Holder           \
+                                                  -m place.holder@mail.com \
+                                                  -r admin
 
 Use the :doc:`upload_sample.py <../scripts/upload_sample.sh>` script to add analysis result and genome signature file to the database.
 
@@ -42,7 +47,7 @@ Use the :doc:`upload_sample.py <../scripts/upload_sample.sh>` script to add anal
 Accessing the web interface
 ---------------------------
 
-To access the web interface, access the URL https://localhost:8010 in your web browser.
+To access the web interface, access the URL https://localhost:8000 in your web browser.
 
 (If this doesn't work, you might want to run ``docker container ls`` and make sure that a container based on the image ``bonsai_frontend`` is available in the list).
 

--- a/frontend/app/config.py
+++ b/frontend/app/config.py
@@ -2,7 +2,7 @@
 import os
 
 # Setup api url
-BONSAI_API_URL = os.getenv("BONSAI_API_URL", "http://localhost:8011")
+BONSAI_API_URL = os.getenv("BONSAI_API_URL", "http://api:8000")
 
 # Session secret key
 SECRET_KEY = b"not-so-secret"


### PR DESCRIPTION
Fixed errors in the default docker-compose file.

### How to setup and perform the tests

1. Clone the repository 
2. Run `docker-compose up -d`
3. Create use `docker-compose exec api bonsai_api create-user -u admin -p admin -m place.holder@mail.com -r admin`
4. Goto, http://localhost:8000 and log in

### Expected outcome 

Login should work
