### PR TITLE
Display lims id and sample id in sample view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,11 @@
 
 ### Added
 
+- Display LIMS id in samples view
+
 ### Changed
+
+- Sample name is being displayed instead of sample id on the samples view
 
 ### Fixed
 

--- a/frontend/app/blueprints/sample/templates/cards.html
+++ b/frontend/app/blueprints/sample/templates/cards.html
@@ -17,7 +17,9 @@
     <div class="card">
         <div class="card-body">
             <div class="d-flex">
-                <h4 id="sample-id-heading" class="card-title">{{sample.sample_id}}</h4>
+                <h4 id="sample-id-heading" class="card-title">
+                    {{ sample.run_metadata.run.sample_name }}
+                </h4>
                 {% for tag in sample.tags %}
                     {% if tag.type == "virulence" %}
                         {% set heading="virulence-heading" %}
@@ -33,6 +35,7 @@
                     </span>
                 {% endfor %}
             </div>
+            <p class="pb-1">LIMS ID: <span class="fst-italic">{{ sample.run_metadata.run.lims_id }}</span></p>
             <div class="row gx-5">
                 <div class="col-md-auto">
                     Upload date: {{sample.created_at | strftime}}


### PR DESCRIPTION
Display sample name and lims id instead of sample id in samples view.

![bild](https://github.com/Clinical-Genomics-Lund/bonsai/assets/12696913/748d90d7-8c6b-4c17-bd61-d905062be533)
