### PR TITLE
167 sourmash clustering does not work with dynamic sample ids

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### Fixed
 
+- Fix minhash sample id lookup by storing sample_id as signautre name when signature is written to disk.
+
 ## [v0.4.0]
 
 ### Added

--- a/minhash_service/minhash_service/minhash/similarity.py
+++ b/minhash_service/minhash_service/minhash/similarity.py
@@ -64,7 +64,8 @@ def get_similar_signatures(
         # read sample results
         signature_path = pathlib.Path(found_sig.filename)
         # extract sample id from sample name
-        base_fname = signature_path.name[: -len(signature_path.suffix)]
+        base_fname = signature_path.name
+        LOG.info("no %d - path: %s -> %s", itr_no, signature_path, base_fname)
         samples.append(SimilarSignature(sample_id=base_fname, similarity=similarity))
 
         # break iteration if limit is reached


### PR DESCRIPTION
This PR fix a bug that prevented sourmash clustering introduced by the new dynamic sample id assignment.

The sample ids are now encoded as signature names when a new signature is written to disk.

Close #167 

### How to setup and perform the tests

1. Checkout repo and setup new Bonsai dev instance
2. Upload a test sample to bonsai, `BONSAI_USER=admin BONSAI_PASSWD=admin  ./upload_sample.py --api http://mtlucmds2.lund.skane.se:8811 -i ./test_sample.yml`
3. Verify that the sourmash signatures were saved in the  `minhash_service` logs
4. To to the uploaded sample and see if the clustering works

### Expected outcome 

Finding similar samples and the dendrogram in the samples view should work.