### PR TITLE
Fix generation of URLs in the samples table when Bonsai is hosted under a URL subpath

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### Fixed
 
 - Fix minhash sample id lookup by storing sample_id as signautre name when signature is written to disk.
+- Links to a sample from the samples tables now works when Bonsai is hosted under a sub-path
 
 ## [v0.4.0]
 

--- a/frontend/app/blueprints/groups/static/sampleTable.js
+++ b/frontend/app/blueprints/groups/static/sampleTable.js
@@ -1,7 +1,11 @@
 import { JSONPath } from "./index-browser-esm.min.js"
 
 export const formatSampleId = (val, params, data) => {
-    const baseUrl = new URL(window.location.href).origin
+    // create base url by stripping the last entry of the path
+    // in case bonsai is not hosted under the root path
+    const groupNamePos = window.location.pathname.split('/').indexOf('groups')
+    const baseUrl = window.location.pathname.split('/').slice(0, groupNamePos).join('/') 
+    console.log(`${window.location.pathname} --> ${baseUrl}`)
     let element = document.createElement('a')
     let path = data.groupId ? `sample/${val.sample_id}?group_id=${data.groupId}` : `sample/${val.sample_id}`
     element.setAttribute('href', `${baseUrl}/${path}`)


### PR DESCRIPTION
Fix generation of URLs in the samples table when Bonsai is hosted under a URL subpath