### PR TITLE
Update bonsai v0.4.0 to v0.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ### Added
 
+### Changed
+
+### Fixed
+
+## [v0.4.1]
+
+### Added
+
 - Display LIMS id in samples view
 
 ### Changed

--- a/frontend/app/__version__.py
+++ b/frontend/app/__version__.py
@@ -1,2 +1,2 @@
 """Bonsai frontend version."""
-VERSION = "0.4.0"
+VERSION = "0.4.1"

--- a/minhash_service/minhash_service/__init__.py
+++ b/minhash_service/minhash_service/__init__.py
@@ -1,3 +1,3 @@
 """Service to perform MinHash based analysis using Sourmash."""
 
-__version__ = "0.1.1"
+__version__ = "0.1.2"


### PR DESCRIPTION
This is a release of Bonsai version 0.4.1

### Added

- Display LIMS id in samples view

### Changed

- Sample name is being displayed instead of sample id on the samples view
- Dockerfile chown step for api and frontend

### Fixed

- Fix minhash sample id lookup by storing sample_id as signautre name when signature is written to disk.
- Links to a sample from the samples tables now works when Bonsai is hosted under a sub-path