### PR TITLE
Release version 0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,20 @@
 ## [Unreleased]
 
 ### Added
+
+### Changed
+
+### Fixed
+
+## [v0.5.0]
+
+### Added
 - Show the same metadata in grapetree as in the sample table from the groups and group view.
+- Added optional LDAP based authentication system
 
 ### Changed
 - Show disabled IGV button for samples without BAM or reference genome. 
+- Updated LIMS export format
 
 ### Fixed
 

--- a/api/app/__version__.py
+++ b/api/app/__version__.py
@@ -1,3 +1,3 @@
 """API version"""
 
-VERSION = "0.4.0"
+VERSION = "0.5.0"

--- a/frontend/app/__version__.py
+++ b/frontend/app/__version__.py
@@ -1,2 +1,2 @@
 """Bonsai frontend version."""
-VERSION = "0.4.1"
+VERSION = "0.5.0"


### PR DESCRIPTION
## [v0.5.0]

### Added
- Show the same metadata in grapetree as in the sample table from the groups and group view.
- Added optional LDAP based authentication system

### Changed
- Show disabled IGV button for samples without BAM or reference genome. 
- Updated LIMS export format