### PR TITLE
Update tbprofiler and mykrobe result

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Added
 
 ### Changed
+- Updated IGVjs to version 2.15.11
 
 ### Fixed
 - Fixed bug in generating mongodb URI

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,11 @@
 ## [Unreleased]
 
 ### Added
+- Added source of tbprofier db entry as badge to result card.
 
 ### Changed
 - Updated IGVjs to version 2.15.11
+- Updated the formatting of the results table in the tbprofiler card.
 
 ### Fixed
 - Fixed bug in generating mongodb URI

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 
 ### Changed
 - Updated IGVjs to version 2.15.11
+- Updated PRP to version 0.8.0
 - Updated the formatting of the results table in the tbprofiler card.
 
 ### Fixed

--- a/api/setup.cfg
+++ b/api/setup.cfg
@@ -33,7 +33,7 @@ install_requires =
     rq==1.16.1
     motor==3.3.2
     pymongo==4.5.0
-    bonsai-prp==0.7.0
+    bonsai-prp==0.8.0
 
 [options.extras_require]
 dev = 

--- a/frontend/app/blueprints/alignviewers/templates/utils.html
+++ b/frontend/app/blueprints/alignviewers/templates/utils.html
@@ -1,5 +1,5 @@
 {% macro igv_script() %}
   <link rel="shortcut icon" href="//igv.org/web/img/favicon.ico">
   <!-- IGV JS-->
-  <script src="https://cdn.jsdelivr.net/npm/igv@2.15.8/dist/igv.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/igv@2.15.11/dist/igv.min.js"></script>
 {% endmacro %}

--- a/frontend/app/blueprints/sample/static/sample.css
+++ b/frontend/app/blueprints/sample/static/sample.css
@@ -80,3 +80,11 @@
   padding: 1rem !important;
   height: fit-content !important; 
 }
+
+.cell-m {
+  width: 2rem !important;
+}
+
+.cell-sm {
+  width: 1rem !important;
+}

--- a/frontend/app/blueprints/sample/templates/cards.html
+++ b/frontend/app/blueprints/sample/templates/cards.html
@@ -569,16 +569,22 @@
                     {% set ref_depth=(variant.depth * (1 - variant.frequency)) %}
                     <tr>
                         <td>{{ variant.ref_nt | upper }}>{{variant.alt_nt | upper }}</td>
-                        <td>{{ variant.variant_type[:3] }}</td>
-                        <td>{{ accession_link(variant.close_seq_name, name=variant.gene_symbol) }}</td>
-                        {% if variant.variant_type == 'substitution' %}
+                        <td>{{ variant.variant_subtype }}</td>
+                        <td>
+                        {% if variant.accession is none %}
+                            {{ variant.reference_sequence }}
+                        {% else %}
+                            {{ accession_link(variant.close_seq_name, name=variant.reference_sequence) }}
+                        {% endif %}
+                        </td>
+                        {% if variant.variant_subtype == 'SUB' %}
                             <td>{{ variant.ref_aa | upper }}>{{variant.alt_aa | upper }}</td>
                         {% else %}
                             <td>-</td>
                         {% endif %}
                         <td>{{ variant.method }}</td>
                         <td>{{ alt_depth | int | fmt_number  }} / {{ ref_depth | int | fmt_number }}</td>
-                        <td>{{ variant.confidence }}</td>
+                        <td>{{ variant.confidence | round | int }}</td>
                         <td>{{ variant.phenotypes[0].name | capitalize }}</td>
                     </tr>
                 {% endfor %}

--- a/frontend/app/blueprints/sample/templates/cards.html
+++ b/frontend/app/blueprints/sample/templates/cards.html
@@ -697,11 +697,13 @@
                                 {% for phenotype in variant.phenotypes %}
                                     <li>
                                         {{ fmt_resistance_info(phenotype) }}
-                                        <span class="badge text-bg-secondary"
-                                            data-bs-toggle="tooltip" data-bs-placement="top"
-                                            data-bs-title="{{ phenotype.source }}">
-                                            {{ phenotype | fmt_db_annotation }}
-                                        </span>
+                                        {% if phenotype.source is not none %}
+                                            <span class="badge text-bg-secondary"
+                                                data-bs-toggle="tooltip" data-bs-placement="top"
+                                                data-bs-title="{{ phenotype.source }}">
+                                                {{ phenotype | fmt_db_annotation }}
+                                            </span>
+                                        {% endif %}
                                         {% if phenotype.note and phenotype.note != "" %}
                                             <span class="badge text-bg-dark"
                                                 data-bs-toggle="tooltip" data-bs-placement="top"

--- a/frontend/app/blueprints/sample/templates/cards.html
+++ b/frontend/app/blueprints/sample/templates/cards.html
@@ -620,6 +620,7 @@
     {% if result.variants | n_results_with_resistance == 0 and not extended %}
         <p class="fw-light fst-italic">No resistance yeilding mutations identified</p>
     {% else %}
+        <div class="table-responsive">
             <table class="table table-sm table-hover table-striped">
                 <thead>
                     <tr>
@@ -641,6 +642,93 @@
                         {% endif %}
                     </tr>
                 </thead>
+                <tbody class="table-group-divider">
+                    {% for variant in result.variants %}
+                        {% if variant.phenotypes | length > 0 or extended %}
+                        {% if variant.verified == "passed" %}
+                            {% set row_class = "table-success" %}
+                        {% elif variant.verified == "failed" %}
+                            {% set row_class = "table-danger" %}
+                        {% endif %}
+                        <tr class="{{ row_class }}">
+                            {% if extended %}
+                                <td>
+                                    <input type="checkbox" class="form-check-input col-auto" name="tbprofiler-{{ variant.id }}" id="tbprofiler-{{ variant.id }}" onclick="selectVariant(this)">
+                                </td>
+                            {% endif %}
+                            <td>
+                                {# TAGS #}
+                                {% if variant.verified == "failed" and variant.reason %}
+                                    <span class="ms-2 badge text-bg-warning"
+                                            data-bs-toggle="tooltip" data-bs-placement="top"
+                                            data-bs-title="{{ variant.reason.description }}" >
+                                        {{ variant.reason.label | upper }}
+                                    </span>
+                                {% endif %}
+                            </td>
+                            <td>
+                                {{ variant.hgvs_nt_change }}
+                            </td>
+                            {% if variant.hgvs_aa_change %}
+                                <td>{{ variant.hgvs_aa_change }}</td>
+                            {% else %}
+                                <td>-</td>
+                            {% endif %}
+                            <td>{{ accession_link(variant.accession, name=variant.reference_sequence) }}</td>
+                            {% if extended %}
+                                <td>{{ variant.variant_effect | replace("_", " ") | replace('variant', '') | capitalize }}</td>
+                            {% endif %}
+                            <td>{{ variant.depth | int }}</td>
+                            <td>
+                                {% if variant.frequency == 1 %}
+                                    100
+                                {% else %}
+                                    {{ (variant.frequency * 100) | round(1) }}
+                                {% endif %}
+                            </td>
+                            <td>
+                                <ul class="no-bullets">
+                                {% for phenotype in variant.phenotypes %}
+                                    <li>
+                                        {{ fmt_resistance_info(phenotype) }}
+                                        <span class="badge text-bg-secondary"
+                                            data-bs-toggle="tooltip" data-bs-placement="top"
+                                            data-bs-title="{{ phenotype.source }}">
+                                            {{ phenotype | fmt_db_annotation }}
+                                        </span>
+                                        {% if phenotype.note and phenotype.note != "" %}
+                                            <span class="badge text-bg-dark"
+                                                data-bs-toggle="tooltip" data-bs-placement="top"
+                                                data-bs-title="WHO group {{phenotype | lookup_who_group }}; {{ phenotype.note }}">
+                                                {{ phenotype | lookup_who_group }}
+                                            </span>
+                                        {% endif %}
+                                    </li>
+                                {% endfor %}
+                                </ul>
+                            </td>
+                            {% if extended %}
+                                <td>
+                                    {% set variant_id = "tbprofiler-{}".format(variant["id"]) %}
+                                    <span class="d-inline-block" tabindex="0"
+                                    {% if not display_igv %}
+                                        data-bs-toggle="tooltip" data-bs-placement="top"
+                                        data-bs-title="Either no reference genome or BAM assigned to the sample."
+                                    {% endif %}>
+                                        <a href="{{ url_for('alignviewers.igv', sample_id=sample.sample_id, variant_id=variant_id) }}"
+                                        type="button" target="_blank" 
+                                        class="btn btn-sm btn-secondary {% if not display_igv %}disabled{% endif %}">
+                                        IGV
+                                        </a>
+                                    </span>
+                                </td>
+                            {% endif %}
+                        </tr>
+                        {% endif %}
+                    {% endfor %}
+                </tbody>
+            </table>
+        </div>
     {% endif %}
 </div>
 {% endmacro %}

--- a/frontend/app/blueprints/sample/templates/cards.html
+++ b/frontend/app/blueprints/sample/templates/cards.html
@@ -620,102 +620,27 @@
     {% if result.variants | n_results_with_resistance == 0 and not extended %}
         <p class="fw-light fst-italic">No resistance yeilding mutations identified</p>
     {% else %}
-        <table class="table table-striped">
-            <thead>
-                <tr>
-                    {% if extended %}
-                        <td scope="col"></td>
-                    {% endif %}
-                    <td scope="col">Tags</td>
-                    <td scope="col">Variant</td>
-                    <td scope="col">Protein change</td>
-                    <td scope="col">Gene</td>
-                    {% if extended %}
-                        <td scope="col">Effect</td>
-                    {% endif %}
-                    <td scope="col">Read depth</td>
-                    <td scope="col">Freq</td>
-                    <td scope="col">Antibiotics</td>
-                    {% if extended %}
-                        <td scope="col"></td>
-                    {% endif %}
-                </tr>
-            </thead>
-            <tbody class="table-group-divider">
-                {% for variant in result.variants %}
-                    {% if variant.phenotypes | length > 0 or extended %}
-                    {% if variant.verified == "passed" %}
-                        {% set row_class = "table-success" %}
-                    {% elif variant.verified == "failed" %}
-                        {% set row_class = "table-danger" %}
-                    {% endif %}
-                    <tr class="{{ row_class }}">
+            <table class="table table-sm table-hover table-striped">
+                <thead>
+                    <tr>
                         {% if extended %}
-                            <td>
-                                <input type="checkbox" class="form-check-input col-auto" name="tbprofiler-{{ variant.id }}" id="tbprofiler-{{ variant.id }}" onclick="selectVariant(this)">
-                            </td>
+                            <td scope="col"></td>
                         {% endif %}
-                        <td>
-                            {% if variant.verified == "failed" and variant.reason %}
-                                <span class="ms-2 badge text-bg-warning"
-                                        data-bs-toggle="tooltip" data-bs-placement="top"
-                                        data-bs-title="{{ variant.reason.description }}" >
-                                    {{ variant.reason.label | upper }}
-                                </span>
-                            {% endif %}
-                            {# Add WHO class as badges #}
-                            {% for phenotype in variant.phenotypes %}
-                                {% if phenotype.note and phenotype.note != "" %}
-                                    <span class="badge text-bg-secondary"
-                                        data-bs-toggle="tooltip" data-bs-placement="top"
-                                        data-bs-title="{{ phenotype.note }}">
-                                        {{ phenotype.note | lookup_who_group }}
-                                    </span>
-                                {% endif %}
-                            {% endfor %}
-                        </td>
-                        <td>
-                            {{ variant.hgvs_nt_change }}
-                        </td>
-                        {% if variant.hgvs_aa_change %}
-                            <td>{{ variant.hgvs_aa_change }}</td>
-                        {% else %}
-                            <td>-</td>
-                        {% endif %}
-                        <td>{{ accession_link(variant.accession, name=variant.reference_sequence) }}</td>
+                        <td scope="col">Tags</td>
+                        <td scope="col">Variant</td>
+                        <td scope="col">Protein change</td>
+                        <td scope="col">Gene</td>
                         {% if extended %}
-                            <td>{{ variant.variant_effect | replace("_", " ") | capitalize }}</td>
+                            <td class="cell-m" scope="col">Effect</td>
                         {% endif %}
-                        <td>{{ variant.depth | int }}</td>
-                        <td>{{ (variant.frequency * 100) | round(1) }}</td>
-                        <td>
-                            <ul class="no-bullets">
-                            {% for phenotype in variant.phenotypes %}
-                                <li>{{ fmt_resistance_info(phenotype) }}</li>
-                            {% endfor %}
-                            </ul>
-                        </td>
+                        <td class="cell-sm" scope="col">Read depth</td>
+                        <td scope="col">Freq</td>
+                        <td scope="col">Antibiotics</td>
                         {% if extended %}
-                            <td>
-                                {% set variant_id = "tbprofiler-{}".format(variant["id"]) %}
-                                <span class="d-inline-block" tabindex="0"
-                                {% if not display_igv %}
-                                    data-bs-toggle="tooltip" data-bs-placement="top"
-                                    data-bs-title="Either no reference genome or BAM assigned to the sample."
-                                {% endif %}>
-                                    <a href="{{ url_for('alignviewers.igv', sample_id=sample.sample_id, variant_id=variant_id) }}"
-                                    type="button" target="_blank" 
-                                    class="btn btn-sm btn-secondary {% if not display_igv %}disabled{% endif %}">
-                                    IGV
-                                    </a>
-                                </span>
-                            </td>
+                            <td scope="col"></td>
                         {% endif %}
                     </tr>
-                    {% endif %}
-                {% endfor %}
-            </tbody>
-        </table>
+                </thead>
     {% endif %}
 </div>
 {% endmacro %}

--- a/frontend/app/blueprints/sample/templates/cards.html
+++ b/frontend/app/blueprints/sample/templates/cards.html
@@ -705,7 +705,7 @@
                                         {% if phenotype.note and phenotype.note != "" %}
                                             <span class="badge text-bg-dark"
                                                 data-bs-toggle="tooltip" data-bs-placement="top"
-                                                data-bs-title="WHO group {{phenotype | lookup_who_group }}; {{ phenotype.note }}">
+                                                data-bs-title="Class {{phenotype | lookup_who_group }} - {{ phenotype.note }}">
                                                 {{ phenotype | lookup_who_group }}
                                             </span>
                                         {% endif %}

--- a/frontend/app/blueprints/sample/templates/cards.html
+++ b/frontend/app/blueprints/sample/templates/cards.html
@@ -638,7 +638,7 @@
                         <td scope="col">Protein change</td>
                         <td scope="col">Gene</td>
                         {% if extended %}
-                            <td class="cell-m" scope="col">Effect</td>
+                            <td scope="col">Effect</td>
                         {% endif %}
                         <td class="cell-sm" scope="col">Read depth</td>
                         <td scope="col">Freq</td>

--- a/frontend/app/bonsai.py
+++ b/frontend/app/bonsai.py
@@ -356,7 +356,7 @@ def update_sample_qc_classification(headers: CaseInsensitiveDict, **kwargs):
 
 @api_authentication
 def update_variant_info(
-    headers: CaseInsensitiveDict, sample_id, *variant_ids, **status
+    headers: CaseInsensitiveDict, sample_id, variant_ids, status
 ):
     """Update annotation of resitance variants for a sample"""
     data = {

--- a/frontend/app/custom_filters.py
+++ b/frontend/app/custom_filters.py
@@ -1,5 +1,6 @@
 """Custom jinja3 template tests."""
 import logging
+import re
 import math
 from collections import defaultdict
 from itertools import chain
@@ -371,7 +372,7 @@ def n_results_with_resistance(results):
     return n_results
 
 
-def get_who_group_from_tbprofiler_comment(comment):
+def get_who_group_from_tbprofiler_comment(comment: Dict[str, str]) -> str | None:
     """Get WHO group from a comment from TbProfiler."""
     # annotate WHO classification
     who_classes = {
@@ -381,10 +382,28 @@ def get_who_group_from_tbprofiler_comment(comment):
         "not assoc w r - interim": 4,
         "not assoc w r": 5,
     }
-    who_group = who_classes.get(comment.lower())
+    who_group = who_classes.get(comment['note'].lower())
     if who_group is not None:
-        return f"WHO-{who_group}"
+        return f"{who_group}"
     return None
+
+
+def format_tbprofiler_db_annotation(comment: Dict[str, str]) -> str:
+    """Shorten TbProfiler source annotation."""
+    db_names = {
+        'tbdb': 'TBDB',
+        'fohm': 'Fohm',
+    }
+    annot_source = comment['source'].lower()
+    who_match = re.search(r'^who.*v(\d+)', annot_source)
+    if annot_source in db_names:
+        fmt_name = db_names[annot_source]
+    elif who_match:
+        version = who_match.group(1)
+        fmt_name = f"WHOv{version}"
+    else:
+        fmt_name = annot_source
+    return fmt_name
 
 
 TESTS = {
@@ -411,4 +430,5 @@ FILTERS = {
     "count_results": count_results,
     "n_results_with_resistance": n_results_with_resistance,
     "lookup_who_group": get_who_group_from_tbprofiler_comment,
+    "fmt_db_annotation": format_tbprofiler_db_annotation,
 }


### PR DESCRIPTION
This PR updates Bonsai to handle TbProfiler v6.2 and introduces minor fixes to the Mykrobe result card.

Changes
- Moves tbprofiler resistance classification to the antibiotic
- Adds a tag that describes the source of the resistance annotation
- Made the tbprofiler card slightly more space efficient

![bild](https://github.com/Clinical-Genomics-Lund/bonsai/assets/12696913/25286a30-3ed3-47bb-b440-84b097fb763b)
