### PR TITLE
191 cant search for sample id in samle view tables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Updated requests to version 2.32.0
 - Added startup commands to minhash and allele clustering services Dockerfiles.
+- Updated the samples tables to make sample name, sample id, and major spp searchable.
 
 ### Fixed
 

--- a/api/app/models/group.py
+++ b/api/app/models/group.py
@@ -50,9 +50,14 @@ class OverviewTableColumn(BaseModel):  # pylint: disable=too-few-public-methods
 
 VALID_COLUMNS = [
     OverviewTableColumn(
+        id="sample_btn",
+        label="Open sample",
+        type="sample_btn",
+        path="$.sample_id",
+    ),
+    OverviewTableColumn(
         id="sample_id",
         label="Sample Id",
-        type="sampleid",
         path="$.sample_id",
         hidden=True,
         sortable=True,
@@ -60,7 +65,6 @@ VALID_COLUMNS = [
     OverviewTableColumn(
         id="sample_name",
         label="Name",
-        type="sampleid",
         path="$.sample_name",
         sortable=True,
     ),
@@ -85,7 +89,6 @@ VALID_COLUMNS = [
     OverviewTableColumn(
         id="taxonomic_name",
         label="Major species",
-        type="taxonomic_name",
         path="$.species_prediction.scientific_name",
         sortable=True,
     ),

--- a/frontend/app/blueprints/groups/static/sampleTable.js
+++ b/frontend/app/blueprints/groups/static/sampleTable.js
@@ -1,5 +1,20 @@
 import { JSONPath } from "./index-browser-esm.min.js"
 
+export const formatOpenSampleBtn = (val, params, data) => {
+    // create base url by stripping the last entry of the path
+    // in case bonsai is not hosted under the root path
+    const groupNamePos = window.location.pathname.split('/').indexOf('groups')
+    const baseUrl = window.location.pathname.split('/').slice(0, groupNamePos).join('/') 
+    console.log(`${window.location.pathname} --> ${baseUrl}`)
+    let element = document.createElement('a')
+    let path = data.groupId ? `sample/${val.sample_id}?group_id=${data.groupId}` : `sample/${val.sample_id}`
+    element.setAttribute('href', `${baseUrl}/${path}`)
+    element.classList.add('btn', 'btn-sm', 'btn-dark', 'br-table-link')
+    //element.classList.add('badge', 'text-bg-info', 'rounded-pill', 'p-1')
+    element.innerText = 'Open'
+    return element.outerHTML
+}
+
 export const formatSampleId = (val, params, data) => {
     // create base url by stripping the last entry of the path
     // in case bonsai is not hosted under the root path
@@ -51,10 +66,11 @@ export const getTableSampleData = (sample, tableConfig) => {
     // add sample id to colums with sampleid type
     const check_sampleid = (col) => {
         let result
-        if (col.type == "sampleid") {
+        if (col.type == "sample_btn") {
             result = {
                 sample_id: JSONPath({path: "$.sample_id", json: sample})[0], 
-                name: JSONPath({path: col.path, json: sample})[0]}
+                name: JSONPath({path: col.path, json: sample})[0]
+            }
         } else {
             result = JSONPath({path: col.path, json: sample})[0]
         }

--- a/frontend/app/blueprints/groups/templates/group.html
+++ b/frontend/app/blueprints/groups/templates/group.html
@@ -55,12 +55,12 @@
 </div>
 <script type="module">
     import { w2grid, w2utils } from 'https://rawgit.com/vitmalina/w2ui/master/dist/w2ui.es6.min.js'
-    import { formatTaxonomicName, formatSampleId, formatTag, getTableSampleData, formatTableColumn } from '{{ url_for("groups.static", filename="sampleTable.js") }}';
+    import { formatTaxonomicName, formatOpenSampleBtn, formatTag, getTableSampleData, formatTableColumn } from '{{ url_for("groups.static", filename="sampleTable.js") }}';
 
     // define formatters
     w2utils.formatters['taxonomic_name'] = formatTaxonomicName
     w2utils.formatters['tags'] = formatTag
-    w2utils.formatters['sampleid'] = formatSampleId
+    w2utils.formatters['sample_btn'] = formatOpenSampleBtn
     // get table configuration
     const apiTableConfig = {{ table_definition | tojson }}
     const groupId = "{{ group_id }}"

--- a/frontend/app/blueprints/groups/templates/groups.html
+++ b/frontend/app/blueprints/groups/templates/groups.html
@@ -49,12 +49,12 @@
 </div>
 <script type="module">
     import { w2grid, w2utils } from 'https://rawgit.com/vitmalina/w2ui/master/dist/w2ui.es6.min.js'
-    import { formatTaxonomicName, formatSampleId, formatTag, getDefaultCols, getTableSampleData, formatTableColumn } from '{{ url_for("groups.static", filename="sampleTable.js") }}';
+    import { formatTaxonomicName, formatOpenSampleBtn, formatTag, getDefaultCols, getTableSampleData, formatTableColumn } from '{{ url_for("groups.static", filename="sampleTable.js") }}';
 
     // define formatters
     w2utils.formatters['taxonomic_name'] = formatTaxonomicName
     w2utils.formatters['tags']  = formatTag
-    w2utils.formatters['sampleid']  = formatSampleId 
+    w2utils.formatters['sample_btn']  = formatOpenSampleBtn 
     // define constants
     const apiURL = "{{ config.BONSAI_API_URL }}"
     const samples = {{ samples | tojson }}

--- a/frontend/app/blueprints/public/static/css/main.css
+++ b/frontend/app/blueprints/public/static/css/main.css
@@ -95,3 +95,8 @@ div#grid_grid_searches.w2ui-grid-searches {
 .toc-collapse {
   display: block !important;
 }
+
+.br-table-link {
+  padding: 0.2rem !important;
+  font-size: small !important;
+}


### PR DESCRIPTION
Updated sample tables in the groups and group view to make the *sample name*, *sample id*, and *major spp* columns searchable.

Closes #191 
