### PR TITLE
Fix sample view alignment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@
 
 ### Fixed
 
-- Fixed missalignment of the checkbox in the samples table in the group and groups view.
+- Fixed misalignment of the checkbox in the samples table in the group and groups view.
 
 ## [v0.6.0]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@
 
 ### Fixed
 
+- Fixed missalignment of the checkbox in the samples table in the group and groups view.
+
 ## [v0.6.0]
 
 ### Added

--- a/frontend/bonsai_app/blueprints/groups/static/sampleTable.js
+++ b/frontend/bonsai_app/blueprints/groups/static/sampleTable.js
@@ -9,7 +9,7 @@ export const formatOpenSampleBtn = (val, params, data) => {
     let element = document.createElement('a')
     let path = data.groupId ? `sample/${val.sample_id}?group_id=${data.groupId}` : `sample/${val.sample_id}`
     element.setAttribute('href', `${baseUrl}/${path}`)
-    element.classList.add('btn', 'btn-sm', 'btn-dark', 'br-table-link')
+    //element.classList.add('btn', 'btn-sm', 'btn-dark', 'br-table-link')
     //element.classList.add('badge', 'text-bg-info', 'rounded-pill', 'p-1')
     element.innerText = 'Open'
     return element.outerHTML


### PR DESCRIPTION
This PR fixes the missalignment of the checkbox in the table that contains all samples.