### PR TITLE
Updated how IGV integration handles annotation tracks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Added cards ShigaPass result and function to tag Ecoli and Shigella spp with ShigaPass result.
 - Added option to filter variants on WHO class and variant type in the variants view.
 - Added button to reset variants filter on the variants view.
+- Added support for more IGV annoation file formats.
 
 ### Changed
 
@@ -17,6 +18,7 @@
 - Use pydantic-settings for config management in frontend.
 - Updated the samples tables to make sample name, sample id, and major spp searchable.
 - Truncate long tbprofiler variant names and show full name on hover.
+- Fixed issue that could prevent IGV from loading.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 - Updated the samples tables to make sample name, sample id, and major spp searchable.
 - Truncate long tbprofiler variant names and show full name on hover.
 - Fixed issue that could prevent IGV from loading.
+- Updated IGVjs to version 3.0.2
 
 ### Fixed
 

--- a/frontend/bonsai_app/blueprints/alignviewers/templates/utils.html
+++ b/frontend/bonsai_app/blueprints/alignviewers/templates/utils.html
@@ -1,5 +1,5 @@
 {% macro igv_script() %}
   <link rel="shortcut icon" href="//igv.org/web/img/favicon.ico">
   <!-- IGV JS-->
-  <script src="https://cdn.jsdelivr.net/npm/igv@2.15.11/dist/igv.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/igv@3.0.2/dist/igv.min.js"></script>
 {% endmacro %}


### PR DESCRIPTION
This PR fixes several issues pertaining to IGV annotation tracks.

- Changed so compressed files can be added
- Allow more file formats for annotation tracks
- Updated IGV to version 3.0.2
- Prevents a crash if the annotation track file format is not recognized.

