### PR TITLE
Update prp to v0.10.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
 ### Changed
 
 - Bonsai now uses sample ids created by Jasen to identify unique samples.
-- Updated PRP to version 0.9.3
+- Updated PRP to version 0.10.1
 - Improved installation instructions.
 - Updated requests to version 2.32.0
 - Added startup commands to minhash and allele clustering services Dockerfiles.
@@ -27,6 +27,7 @@
 - Fixed misalignment of the checkbox in the samples table in the group and groups view.
 - Fixed bug in the TB lineage card that could crash the frontend.
 - Fixed an issue where samples without MLST profiles could crash GrapeTree.
+- Fixed removal of new ChewBBACA alleles call info codes.
 
 ## [v0.6.0]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,8 @@
 ### Fixed
 
 - Fixed misalignment of the checkbox in the samples table in the group and groups view.
-- Fixed bug in the TB lineage card that could crash the frontend
+- Fixed bug in the TB lineage card that could crash the frontend.
+- Fixed an issue where samples without MLST profiles could crash GrapeTree.
 
 ## [v0.6.0]
 

--- a/api/bonsai_api/crud/sample.py
+++ b/api/bonsai_api/crud/sample.py
@@ -668,7 +668,6 @@ async def get_typing_profiles(
     # query database
     results = []
     async for raw_typing_profile in db.sample_collection.aggregate(pipeline):
-        #raise ValueError(raw_typing_profile.keys())
         results.append(
             TypingProfileAggregate(
                 sample_id=raw_typing_profile['sample_id'],

--- a/api/setup.cfg
+++ b/api/setup.cfg
@@ -33,7 +33,7 @@ install_requires =
     rq==1.16.1
     motor==3.3.2
     pymongo==4.5.0
-    bonsai-prp==0.10.0
+    bonsai-prp==0.10.1
     
 [options.extras_require]
 dev = 

--- a/frontend/bonsai_app/blueprints/cluster/views.py
+++ b/frontend/bonsai_app/blueprints/cluster/views.py
@@ -6,7 +6,7 @@ from typing import Any, Dict, List
 
 from flask import Blueprint, flash, redirect, render_template, request, url_for
 from flask_login import current_user, login_required
-from pydantic import BaseModel
+from pydantic import BaseModel, ConfigDict
 from requests.exceptions import HTTPError
 
 from ...bonsai import (
@@ -35,10 +35,7 @@ class DataPointStyle(BaseModel):  # pylint: disable=too-few-public-methods
     grouptype: str = "alphabetic"
     colorscheme: DataType
 
-    class Config:  # pylint: disable=too-few-public-methods
-        """Configure model to resolve Enum values."""
-
-        use_enum_values = True
+    model_config = ConfigDict(use_enum_values=True)
 
 
 class MetaData(BaseModel):  # pylint: disable=too-few-public-methods

--- a/frontend/bonsai_app/blueprints/cluster/views.py
+++ b/frontend/bonsai_app/blueprints/cluster/views.py
@@ -41,7 +41,7 @@ class DataPointStyle(BaseModel):  # pylint: disable=too-few-public-methods
 class MetaData(BaseModel):  # pylint: disable=too-few-public-methods
     """Structure of metadata options"""
 
-    metadata: Dict[str, Dict[str, str | int | float]]
+    metadata: Dict[str, Dict[str, str | int | float | None]]
     metadata_list: list[str]
     metadata_options: Dict[str, DataPointStyle]
 


### PR DESCRIPTION
This PR updates PRP to v0.10.1. This also introduces the following fixes,
- Fixed an issue where some ChewBBACA allele caller error mesages was not stripped prior to clustering
- Fixed an issue that could cause the GrapeTree to crash.
