### PR TITLE
Release v0.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ### Added
 
+### Changed
+
+### Fixed
+
+## [v0.7.0]
+
+### Added
+
 - Can configure SSL verification and usage of SSL certs for API requests from frontend.
 - Added cards ShigaPass result and function to tag Ecoli and Shigella spp with ShigaPass result.
 - Added option to filter variants on WHO class and variant type in the variants view.

--- a/allele_cluster_service/allele_cluster_service/__init__.py
+++ b/allele_cluster_service/allele_cluster_service/__init__.py
@@ -1,2 +1,2 @@
 """Version of allele cluster service."""
-__version__ = "0.1.0"
+__version__ = "0.2.0"

--- a/api/bonsai_api/__version__.py
+++ b/api/bonsai_api/__version__.py
@@ -1,3 +1,3 @@
 """API version"""
 
-VERSION = "0.6.0"
+VERSION = "0.7.0"

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -38,7 +38,7 @@ Use docker-compose to get started creating the Bonsai containers and configure t
             - bonsai-net
 
       frontend:
-         image: clinicalgenomicslund/bonsai-app:0.6.0 
+         image: clinicalgenomicslund/bonsai-app:0.7.0 
          depends_on:
             - mongodb
             - api
@@ -48,7 +48,7 @@ Use docker-compose to get started creating the Bonsai containers and configure t
             - bonsai-net
 
       api:
-         image: clinicalgenomicslund/bonsai-api:0.6.0 
+         image: clinicalgenomicslund/bonsai-api:0.7.0 
          depends_on:
             - mongodb
             - minhash_service
@@ -59,7 +59,7 @@ Use docker-compose to get started creating the Bonsai containers and configure t
             - bonsai-net
 
       minhash_service:
-         image: clinicalgenomicslund/bonsai-minhash-clustering:0.1.2 
+         image: clinicalgenomicslund/bonsai-minhash-clustering:0.2.0 
          depends_on:
             - redis
          volumes:
@@ -68,7 +68,7 @@ Use docker-compose to get started creating the Bonsai containers and configure t
             - bonsai-net
 
       allele_cluster_service:
-         image: clinicalgenomicslund/bonsai-allele-clustering:0.1.0
+         image: clinicalgenomicslund/bonsai-allele-clustering:0.2.0
          depends_on:
             - redis
          networks:

--- a/frontend/bonsai_app/__version__.py
+++ b/frontend/bonsai_app/__version__.py
@@ -1,2 +1,2 @@
 """Bonsai frontend version."""
-VERSION = "0.6.0"
+VERSION = "0.7.0"

--- a/minhash_service/minhash_service/__init__.py
+++ b/minhash_service/minhash_service/__init__.py
@@ -1,3 +1,3 @@
 """Service to perform MinHash based analysis using Sourmash."""
 
-__version__ = "0.1.2"
+__version__ = "0.2.0"


### PR DESCRIPTION
### Added

- Can configure SSL verification and usage of SSL certs for API requests from frontend.
- Added cards ShigaPass result and function to tag Ecoli and Shigella spp with ShigaPass result.
- Added option to filter variants on WHO class and variant type in the variants view.
- Added button to reset variants filter on the variants view.
- Added support for more IGV annoation file formats.

### Changed

- Bonsai now uses sample ids created by Jasen to identify unique samples.
- Updated PRP to version 0.10.1
- Improved installation instructions.
- Updated requests to version 2.32.0
- Added startup commands to minhash and allele clustering services Dockerfiles.
- Use pydantic-settings for config management in frontend.
- Updated the samples tables to make sample name, sample id, and major spp searchable.
- Truncate long tbprofiler variant names and show full name on hover.
- Fixed issue that could prevent IGV from loading.
- Updated IGVjs to version 3.0.2
- Updaed how AMR variants are displayed on the sample view page. All varians are displayed if no variant have been processed, otherwise only show passed resistance yielding variants.

### Fixed

- Fixed misalignment of the checkbox in the samples table in the group and groups view.
- Fixed bug in the TB lineage card that could crash the frontend.
- Fixed an issue where samples without MLST profiles could crash GrapeTree.
- Fixed removal of new ChewBBACA alleles call info codes