### PR TITLE
217 add select all button for variants in variants view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### Added
 
+- Added select all variants button to tbprofiler and SV cards in Variant report view.
+
 ### Changed
 
 ### Fixed

--- a/frontend/bonsai_app/blueprints/sample/templates/cards.html
+++ b/frontend/bonsai_app/blueprints/sample/templates/cards.html
@@ -666,7 +666,9 @@
                 <thead>
                     <tr>
                         {% if extended %}
-                            <td scope="col"></td>
+                            <td scope="col">
+                                <input type="checkbox" class="form-check-input col-auto" onclick="selectAllVariants(this, 'tbprofiler-variant-table')">
+                            </td>
                         {% endif %}
                         <td scope="col">Tags</td>
                         <td scope="col">Variant</td>
@@ -683,7 +685,7 @@
                         {% endif %}
                     </tr>
                 </thead>
-                <tbody class="table-group-divider">
+                <tbody id="tbprofiler-variant-table" class="table-group-divider">
                     {% for variant in result.variants %}
                         {% if variant.phenotypes | length > 0 or extended %}
                         {% if variant.verified == "passed" %}

--- a/frontend/bonsai_app/blueprints/sample/templates/resistance_variants.html
+++ b/frontend/bonsai_app/blueprints/sample/templates/resistance_variants.html
@@ -25,7 +25,9 @@
         <table class="table">
             <thead>
                 <tr>
-                    <th></th>
+                    <th>
+                        <input type="checkbox" class="form-check-input col-auto" onclick="selectAllVariants(this, 'sv-variant-table')">
+                    </th>
                     <th>Info</th>
                     <th>Subtype</th>
                     <th>Start</th>
@@ -36,7 +38,7 @@
                     <th></th>
                 </tr>
             </thead>
-            <tbody>
+            <tbody id="sv-variant-table">
                 {% for variant in variants %}
                     {% if variant.verified == "passed" %}
                         {% set row_class = "table-success" %}
@@ -44,7 +46,7 @@
                         {% set row_class = "table-danger" %}
                     {% endif %}
                     <tr class="{{ row_class }}">
-                        <td><input type="checkbox" name="sv_variants-{{ variant.id }}" id="sv_variant-{{ variant.id }}" onclick="selectVariant(this)"></td>
+                        <td><input type="checkbox"  class="form-check-input col-auto" name="sv_variants-{{ variant.id }}" id="sv_variant-{{ variant.id }}" onclick="selectVariant(this)"></td>
                         <td>
                             {% if variant.verified == "failed" and variant.reason %}
                                 <span class="ms-2 badge text-bg-warning"
@@ -321,5 +323,11 @@
         window.localStorage.setItem("selectedVariants", variantsObj)
     }
     // reset selected varants on page load
+    const selectAllVariants = (elem, tableId) => {
+        document.getElementById(tableId).querySelectorAll("input[type=checkbox]").forEach(el => {
+            el.checked = elem.checked; 
+            selectVariant(el);
+        });
+    }
 </script>
 {% endblock content %}


### PR DESCRIPTION
This PR adds a select all button to Tbprofiler and SV variants in the Variant report view.

![Animation](https://github.com/user-attachments/assets/dd50ded5-a4a9-4b5c-a738-0cca3c1ea81e)

### How to setup and perform the tests

1. Setup dev instance of Bonsai or use this http://mtlucmds2.lund.skane.se:8812
2. Load a few Tb samples
3. Goto `/sample/<sample_id>/resistance/variants`
4. Test to filter the variants and then process them.

### Expected outcome 

The select all button should work as expected.

### Additional context

