### PR TITLE
Add foundation for testing API routes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Added button to the groups view for adding selected samples to group.
 - Added button to the group view for removing selected samples from group.
 - Added column with comments indicator to group and groups view.
+- Added foundation for testing API routes.
 
 ### Changed
 

--- a/api/bonsai_api/config.py
+++ b/api/bonsai_api/config.py
@@ -34,6 +34,7 @@ class Settings(BaseSettings):
     # authentication options
     secret_key: str = "not-so-secret"  # openssl rand -hex 32
     access_token_expire_minutes: int = 180  # expiration time for accesst token
+    api_authentication: bool = True
     # LDAP login Settings
     # If LDAP is not configured it will fallback on local authentication
     ldap_search_attr: str = "mail"

--- a/api/bonsai_api/crud/user.py
+++ b/api/bonsai_api/crud/user.py
@@ -1,6 +1,6 @@
 """User CRUD operations."""
 import logging
-from typing import List
+from typing import List, Annotated
 
 from fastapi import Depends, HTTPException, Security, status
 from fastapi.encoders import jsonable_encoder
@@ -109,7 +109,8 @@ async def authenticate_user(db_obj: Database, username: str, password: str) -> b
 
 
 async def get_current_user(
-    security_scopes: SecurityScopes, token: str = Depends(oauth2_scheme)
+    security_scopes: SecurityScopes, 
+    token: Annotated[str, Depends(oauth2_scheme)]
 ) -> UserOutputDatabase:
     """Get current user."""
     if security_scopes.scopes:

--- a/api/bonsai_api/db/__init__.py
+++ b/api/bonsai_api/db/__init__.py
@@ -1,3 +1,4 @@
 """Module for interfacing with mongodb."""
 
-from .db import Database, db
+from .db import MongoDatabase as Database
+from .utils import db, get_db

--- a/api/bonsai_api/db/db.py
+++ b/api/bonsai_api/db/db.py
@@ -8,7 +8,7 @@ from ..config import settings
 LOG = logging.getLogger(__name__)
 
 
-class Database:  # pylint: disable=too-few-public-methods
+class MongoDatabase:  # pylint: disable=too-few-public-methods
     """Container for database connection and collections."""
 
     def __init__(self) -> None:
@@ -30,6 +30,3 @@ class Database:  # pylint: disable=too-few-public-methods
         self.sample_collection: AsyncIOMotorCollection = self.db.sample
         self.location_collection: AsyncIOMotorCollection = self.db.location
         self.user_collection: AsyncIOMotorCollection = self.db.user
-
-
-db = Database()

--- a/api/bonsai_api/db/utils.py
+++ b/api/bonsai_api/db/utils.py
@@ -4,25 +4,24 @@ import logging
 from motor.motor_asyncio import AsyncIOMotorClient
 
 from ..config import settings
-from .db import db
+from .db import MongoDatabase
 
 LOG = logging.getLogger(__name__)
 
+db = MongoDatabase()
 
-def connect_to_mongo():
-    """Setup connection to mongo database."""
-    LOG.info("Initiate connection to mongo database")
+
+def get_db() -> MongoDatabase:
+    """Set up database connection."""
     db.client = AsyncIOMotorClient(
         settings.mongodb_uri,
         maxPoolSize=settings.max_connections,
         minPoolSize=settings.min_connections,
     )
-    db.setup()  # initiate collections
-    LOG.info("Connection successfull")
-
-
-async def close_mongo_connection():
-    """Teardown connection to mongo database."""
-    LOG.info("Initiate teardown of database connection")
-    db.client.close()
-    LOG.info("Teardown successfull")
+    try:
+        LOG.debug("Setup connection to mongo database")
+        db.setup()  # initiate collections
+        yield db
+    finally:
+        db.client.close()
+        LOG.debug("Initiate teardown of database connection")

--- a/api/bonsai_api/main.py
+++ b/api/bonsai_api/main.py
@@ -1,6 +1,7 @@
 """Main entrypoint for API server."""
 
-from logging.config import dictConfig
+import logging
+import logging.config as logging_config
 
 from fastapi import FastAPI
 
@@ -20,7 +21,7 @@ from .routers import (
     users,
 )
 
-dictConfig(
+logging_config.dictConfig(
     {
         "version": 1,
         "disable_existing_loggers": False,
@@ -39,11 +40,16 @@ dictConfig(
         "root": {"level": "DEBUG", "handlers": ["wsgi"]},
     }
 )
+LOG = logging.getLogger(__name__)
 
 app = FastAPI(title="Bonsai")
 
 # configure CORS
 configure_cors(app)
+
+# check if api authentication is disabled
+if not settings.api_authentication:
+    LOG.warning("API authentication disabled!")
 
 # configure events
 if settings.use_ldap_auth:

--- a/api/bonsai_api/main.py
+++ b/api/bonsai_api/main.py
@@ -5,7 +5,6 @@ from logging.config import dictConfig
 from fastapi import FastAPI
 
 from .config import settings
-from .db.utils import close_mongo_connection, connect_to_mongo
 from .extensions.ldap_extension import ldap_connection
 from .internal.middlewares import configure_cors
 from .routers import (
@@ -47,9 +46,6 @@ app = FastAPI(title="Bonsai")
 configure_cors(app)
 
 # configure events
-app.add_event_handler("startup", connect_to_mongo)
-app.add_event_handler("shutdown", close_mongo_connection)
-
 if settings.use_ldap_auth:
     app.add_event_handler("startup", ldap_connection.init_app)
     app.add_event_handler("shutdown", ldap_connection.teardown)

--- a/api/bonsai_api/models/group.py
+++ b/api/bonsai_api/models/group.py
@@ -2,7 +2,7 @@
 from typing import Dict, List
 
 from prp.models.phenotype import ElementType
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, ConfigDict
 
 from .base import DBModelMixin, ModifiedAtRWModel, ObjectId
 from .sample import SampleSummary
@@ -15,10 +15,7 @@ class IncludedSamples(ModifiedAtRWModel):  # pylint: disable=too-few-public-meth
 
     included_samples: List[str | SampleSummary]
 
-    class Config:  # pylint: disable=too-few-public-methods
-        """Make mongodb object id serializable."""
-
-        json_encoders = {ObjectId: str}
+    model_config = ConfigDict(json_encoders={ObjectId: str})
 
 
 class UpdateIncludedSamples(IncludedSamples):  # pylint: disable=too-few-public-methods

--- a/api/bonsai_api/routers/auth.py
+++ b/api/bonsai_api/routers/auth.py
@@ -20,8 +20,8 @@ DEFAULT_TAGS = [
 @router.post("/token", tags=DEFAULT_TAGS)
 async def login_for_access_token(form_data: OAuth2PasswordRequestForm = Depends()):
     """Generate a new Oauth2 token."""
-    user: bool = await authenticate_user(db, form_data.username, form_data.password)
-    if not user:
+    is_authenticated: bool = await authenticate_user(db, form_data.username, form_data.password)
+    if not is_authenticated:
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail="Incorrect username or password",

--- a/api/bonsai_api/routers/cluster.py
+++ b/api/bonsai_api/routers/cluster.py
@@ -3,16 +3,16 @@ import logging
 from pathlib import Path
 from typing import Dict
 
-from fastapi import APIRouter, HTTPException, status
+from fastapi import APIRouter, HTTPException, status, Depends
 from pydantic import Field, ConfigDict
 
+from ..db import Database, get_db
 from ..crud.errors import EntryNotFound
 from ..crud.sample import (
     TypingProfileOutput,
     get_signature_path_for_samples,
     get_typing_profiles,
 )
-from ..db import db
 from ..models.base import RWModel
 from ..redis import (
     ClusterMethod,
@@ -60,6 +60,7 @@ class ClusterInput(RWModel):  # pylint: disable=too-few-public-methods
 async def cluster_samples(
     typing_method: TypingMethod,
     cluster_input: ClusterInput,
+    db: Database = Depends(get_db),
 ) -> SubmittedJob:
     """Cluster samples on their cgmlst profile.
 

--- a/api/bonsai_api/routers/cluster.py
+++ b/api/bonsai_api/routers/cluster.py
@@ -4,7 +4,7 @@ from pathlib import Path
 from typing import Dict
 
 from fastapi import APIRouter, HTTPException, status
-from pydantic import Field
+from pydantic import Field, ConfigDict
 
 from ..crud.errors import EntryNotFound
 from ..crud.sample import (
@@ -48,10 +48,7 @@ class ClusterInput(RWModel):  # pylint: disable=too-few-public-methods
     distance: DistanceMethod | None = None
     method: ClusterMethod | MsTreeMethods
 
-    class Config:  # pylint: disable=too-few-public-methods
-        """Model configuration class."""
-
-        use_enum_values = False
+    model_config = ConfigDict(use_enum_values=False)
 
 
 @router.post(

--- a/api/bonsai_api/routers/export.py
+++ b/api/bonsai_api/routers/export.py
@@ -1,14 +1,15 @@
 import logging
 
-from fastapi import APIRouter, HTTPException, Path, Security, status
+from fastapi import APIRouter, HTTPException, Path, Security, status, Depends
 from fastapi.responses import PlainTextResponse
 
 from ..crud.sample import EntryNotFound, get_sample
 from ..crud.user import get_current_active_user
-from ..db import db
+from ..db import Database, get_db
 from ..io import sample_to_kmlims
 from ..models.sample import SAMPLE_ID_PATTERN
 from ..models.user import UserOutputDatabase
+from .shared import SAMPLE_ID_PATH
 
 LOG = logging.getLogger(__name__)
 router = APIRouter()
@@ -25,13 +26,8 @@ UPDATE_PERMISSION = "samples:update"
     "/export/{sample_id}/lims", response_class=PlainTextResponse, tags=DEFAULT_TAGS
 )
 async def export_to_lims(
-    sample_id: str = Path(
-        ...,
-        title="ID of the sample to get",
-        min_length=3,
-        max_length=100,
-        regex=SAMPLE_ID_PATTERN,
-    ),
+    sample_id: str = SAMPLE_ID_PATH,
+    db: Database = Depends(get_db),
     current_user: UserOutputDatabase = Security(  # pylint: disable=unused-argument
         get_current_active_user, scopes=[READ_PERMISSION]
     ),

--- a/api/bonsai_api/routers/groups.py
+++ b/api/bonsai_api/routers/groups.py
@@ -2,7 +2,7 @@
 
 from typing import List
 
-from fastapi import APIRouter, HTTPException, Path, Security, status
+from fastapi import APIRouter, HTTPException, Path, Security, status, Depends
 from fastapi.encoders import jsonable_encoder
 from pymongo.errors import DuplicateKeyError
 
@@ -11,7 +11,7 @@ from ..crud.group import append_sample_to_group
 from ..crud.group import create_group as create_group_record
 from ..crud.group import delete_group, get_group, get_groups, update_group
 from ..crud.user import get_current_active_user
-from ..db import db
+from ..db import Database, get_db
 from ..models.group import VALID_COLUMNS, GroupInCreate, GroupInfoDatabase
 from ..models.user import UserOutputDatabase
 
@@ -32,6 +32,7 @@ async def get_valid_columns():
 
 @router.get("/groups/", response_model=List[GroupInfoDatabase], tags=DEFAULT_TAGS)
 async def get_groups_in_db(
+    db: Database = Depends(get_db),
     current_user: UserOutputDatabase = Security(  # pylint: disable=unused-argument
         get_current_active_user, scopes=[READ_PERMISSION]
     )
@@ -49,6 +50,7 @@ async def get_groups_in_db(
 )
 async def create_group(
     group_info: GroupInCreate,
+    db: Database = Depends(get_db),
     current_user: UserOutputDatabase = Security(  # pylint: disable=unused-argument
         get_current_active_user, scopes=[WRITE_PERMISSION]
     ),
@@ -72,6 +74,7 @@ async def create_group(
 async def get_group_in_db(
     group_id: str,
     lookup_samples: bool = False,
+    db: Database = Depends(get_db),
     current_user: UserOutputDatabase = Security(  # pylint: disable=unused-argument
         get_current_active_user, scopes=[READ_PERMISSION]
     ),
@@ -88,6 +91,7 @@ async def get_group_in_db(
 )
 async def delete_group_from_db(
     group_id: str,
+    db: Database = Depends(get_db),
     current_user: UserOutputDatabase = Security(  # pylint: disable=unused-argument
         get_current_active_user, scopes=[WRITE_PERMISSION]
     ),
@@ -106,6 +110,7 @@ async def delete_group_from_db(
 async def update_group_info(
     group_id: str,
     group_info: GroupInCreate,
+    db: Database = Depends(get_db),
     current_user: UserOutputDatabase = Security(  # pylint: disable=unused-argument
         get_current_active_user, scopes=[WRITE_PERMISSION]
     ),
@@ -127,6 +132,7 @@ async def update_group_info(
 async def add_sample_to_group(
     sample_id: str,
     group_id: str = Path(..., tilte="The id of the group to get"),
+    db: Database = Depends(get_db),
     current_user: UserOutputDatabase = Security(  # pylint: disable=unused-argument
         get_current_active_user, scopes=[WRITE_PERMISSION]
     ),

--- a/api/bonsai_api/routers/groups.py
+++ b/api/bonsai_api/routers/groups.py
@@ -171,6 +171,7 @@ async def get_samples_in_group(
     skip: int = 0,
     limit: int = 0,
     group_id: str = Path(..., tilte="The id of the group to get"),
+    db: Database = Depends(get_db),
     current_user: UserOutputDatabase = Security(  # pylint: disable=unused-argument
         get_current_active_user, scopes=[READ_PERMISSION]
     ),

--- a/api/bonsai_api/routers/locations.py
+++ b/api/bonsai_api/routers/locations.py
@@ -1,7 +1,7 @@
 """Routers for reading or manipulating locations."""
 from typing import List
 
-from fastapi import APIRouter, HTTPException, Query, Security, status
+from fastapi import APIRouter, HTTPException, Query, Security, status, Depends
 
 from ..crud.errors import EntryNotFound
 from ..crud.location import create_location as create_location_from_db
@@ -9,7 +9,7 @@ from ..crud.location import get_location as get_location_from_db
 from ..crud.location import get_locations as get_locations_from_db
 from ..crud.location import get_locations_within_bbox
 from ..crud.user import get_current_active_user
-from ..db import db
+from ..db import Database, get_db
 from ..models.location import (
     GeoJSONPolygon,
     LocationInputCreate,
@@ -30,6 +30,7 @@ WRITE_PERMISSION = "locations:write"
 async def get_locations(
     limit: int = Query(10, gt=0),
     skip: int = Query(0, gt=-1),
+    db: Database = Depends(get_db),
     current_user: UserOutputDatabase = Security(  # pylint: disable=unused-argument
         get_current_active_user, scopes=[READ_PERMISSION]
     ),
@@ -52,6 +53,7 @@ async def get_locations(
 @router.post("/locations/", tags=DEFAULT_TAGS)
 async def create_location(
     location: LocationInputCreate,
+    db: Database = Depends(get_db),
     current_user: UserOutputDatabase = Security(  # pylint: disable=unused-argument
         get_current_active_user, scopes=[WRITE_PERMISSION]
     ),
@@ -75,6 +77,7 @@ async def get_location_bbox(
     bottom: float,
     right: float,
     top: float,
+    db: Database = Depends(get_db),
     current_user: UserOutputDatabase = Security(  # pylint: disable=unused-argument
         get_current_active_user, scopes=[READ_PERMISSION]
     ),
@@ -108,6 +111,7 @@ async def get_location_bbox(
 @router.get("/locations/{location_id}", tags=DEFAULT_TAGS)
 async def get_location(
     location_id: str,
+    db: Database = Depends(get_db),
     current_user: UserOutputDatabase = Security(  # pylint: disable=unused-argument
         get_current_active_user, scopes=[READ_PERMISSION]
     ),

--- a/api/bonsai_api/routers/samples.py
+++ b/api/bonsai_api/routers/samples.py
@@ -80,14 +80,6 @@ class SearchBody(BaseModel):  # pylint: disable=too-few-public-methods
     skip: int = 0
 
 
-SAMPLE_ID_PATH: str = Path(
-    ...,
-    title="ID of the sample to get",
-    min_length=3,
-    max_length=100,
-    pattern=SAMPLE_ID_PATTERN,
-),
-
 DEFAULT_TAGS = [
     "samples",
 ]

--- a/api/bonsai_api/routers/shared.py
+++ b/api/bonsai_api/routers/shared.py
@@ -1,0 +1,12 @@
+"""Resources shared by many routers."""
+from fastapi import Path
+from ..models.sample import SAMPLE_ID_PATTERN
+
+
+SAMPLE_ID_PATH: str = Path(
+    ...,
+    title="ID of the sample to get",
+    min_length=3,
+    max_length=100,
+    pattern=SAMPLE_ID_PATTERN,
+)

--- a/api/bonsai_api/routers/users.py
+++ b/api/bonsai_api/routers/users.py
@@ -3,7 +3,7 @@
 import logging
 from typing import List
 
-from fastapi import APIRouter, HTTPException, Security, status
+from fastapi import APIRouter, HTTPException, Security, status, Depends
 from pymongo.errors import DuplicateKeyError
 
 from ..crud.errors import EntryNotFound, UpdateDocumentError
@@ -18,7 +18,7 @@ from ..crud.user import (
     remove_samples_from_user_basket,
     update_user,
 )
-from ..db import db
+from ..db import Database, get_db
 from ..models.user import SampleBasketObject, UserInputCreate, UserOutputDatabase
 
 LOG = logging.getLogger(__name__)
@@ -35,6 +35,7 @@ WRITE_PERMISSION = "users:write"
 
 @router.get("/users/me", tags=DEFAULT_TAGS, response_model=UserOutputDatabase)
 async def get_users_me(
+    db: Database = Depends(get_db),
     current_user: UserOutputDatabase = Security(
         get_current_active_user, scopes=[OWN_USER]
     ),
@@ -45,6 +46,7 @@ async def get_users_me(
 
 @router.get("/users/basket", tags=DEFAULT_TAGS)
 async def get_samples_in_basket(
+    db: Database = Depends(get_db),
     current_user: UserOutputDatabase = Security(
         get_current_active_user, scopes=[OWN_USER]
     )
@@ -59,6 +61,7 @@ async def get_samples_in_basket(
 @router.put("/users/basket", tags=DEFAULT_TAGS)
 async def add_samples_to_basket(
     samples: List[SampleBasketObject],
+    db: Database = Depends(get_db),
     current_user: UserOutputDatabase = Security(
         get_current_active_user, scopes=[OWN_USER]
     ),
@@ -84,6 +87,7 @@ async def add_samples_to_basket(
 @router.delete("/users/basket", tags=DEFAULT_TAGS)
 async def remove_samples_from_basket(
     sample_ids: List[str],
+    db: Database = Depends(get_db),
     current_user: UserOutputDatabase = Security(
         get_current_active_user, scopes=[OWN_USER]
     ),
@@ -109,6 +113,7 @@ async def remove_samples_from_basket(
 @router.get("/users/{username}", tags=DEFAULT_TAGS)
 async def get_user_in_db(
     username: str,
+    db: Database = Depends(get_db),
     current_user: UserOutputDatabase = Security(  # pylint: disable=unused-argument
         get_current_active_user, scopes=[READ_PERMISSION]
     ),
@@ -127,6 +132,7 @@ async def get_user_in_db(
 @router.delete("/users/{username}", tags=DEFAULT_TAGS)
 async def delete_user_from_db(
     username: str,
+    db: Database = Depends(get_db),
     current_user: UserOutputDatabase = Security(  # pylint: disable=unused-argument
         get_current_active_user, scopes=[WRITE_PERMISSION]
     ),
@@ -151,6 +157,7 @@ async def delete_user_from_db(
 async def update_user_info(
     username: str,
     user: UserInputCreate,
+    db: Database = Depends(get_db),
     current_user: UserOutputDatabase = Security(  # pylint: disable=unused-argument
         get_current_active_user, scopes=[WRITE_PERMISSION]
     ),
@@ -174,6 +181,7 @@ async def update_user_info(
 
 @router.get("/users/", status_code=status.HTTP_201_CREATED, tags=DEFAULT_TAGS)
 async def get_users_in_db(
+    db: Database = Depends(get_db),
     current_user: UserOutputDatabase = Security(  # pylint: disable=unused-argument
         get_current_active_user, scopes=[READ_PERMISSION]
     ),
@@ -186,6 +194,7 @@ async def get_users_in_db(
 @router.post("/users/", status_code=status.HTTP_201_CREATED, tags=DEFAULT_TAGS)
 async def create_user_in_db(
     user: UserInputCreate,
+    db: Database = Depends(get_db),
     current_user: UserOutputDatabase = Security(  # pylint: disable=unused-argument
         get_current_active_user, scopes=[WRITE_PERMISSION]
     ),

--- a/api/pyproject.toml
+++ b/api/pyproject.toml
@@ -8,3 +8,6 @@ plugins = "pydantic.mypy"
 [tool.isort]
 profile = "black"
 src_paths = ["isort", "test"]
+
+[tool.pytest_env]
+API_AUTHENTICATION = false

--- a/api/setup.cfg
+++ b/api/setup.cfg
@@ -42,6 +42,7 @@ dev =
     pytest
     pytest-asyncio
     pytest-mock
+    pytest-env
     httpx
     mongomock
     mongomock-motor

--- a/api/setup.cfg
+++ b/api/setup.cfg
@@ -22,9 +22,8 @@ install_requires =
     wheel
     uvicorn[standard]==0.25.0
     click==8.1.7
-    fastapi[all]==0.108.0
+    fastapi[all]==0.115.0
     python-jose[cryptography]==3.3.0
-    python-multipart==0.0.6
     passlib==1.7.4
     bcrypt==4.1.1
     ldap3==2.9.1
@@ -43,6 +42,7 @@ dev =
     pytest
     pytest-asyncio
     pytest-mock
+    httpx
     mongomock
     mongomock-motor
 

--- a/api/tests/conftest.py
+++ b/api/tests/conftest.py
@@ -1,7 +1,5 @@
 import asyncio
 import json
-from pathlib import Path
-from dotenv import load_dotenv
 from  fastapi.testclient import TestClient
 
 
@@ -68,9 +66,3 @@ def fastapi_client(sample_database):
     client = TestClient(app)
 
     return client
-
-
-def pytest_configure(config):
-    """Configure environment variables used for test."""
-    test_env = str(Path(__file__).parent / "test.env")
-    load_dotenv(test_env, override=True)

--- a/api/tests/conftest.py
+++ b/api/tests/conftest.py
@@ -57,13 +57,13 @@ async def sample_database(mongo_database, mtuberculosis_sample_path):
 
 
 @pytest.fixture()
-def fastapi_client(mongo_database):
+def fastapi_client(sample_database):
     """Setup API test client."""
     # disable authentication for test client
     app.dependency_overrides[oauth2_scheme] = lambda: ""
 
     # use mocked mongo database
-    app.dependency_overrides[get_db] = lambda: mongo_database
+    app.dependency_overrides[get_db] = lambda: sample_database
 
     client = TestClient(app)
 

--- a/api/tests/conftest.py
+++ b/api/tests/conftest.py
@@ -1,11 +1,17 @@
 import asyncio
 import json
 from pathlib import Path
+from dotenv import load_dotenv
+from  fastapi.testclient import TestClient
+
 
 import pytest
 from bonsai_api.crud.sample import create_sample
-from bonsai_api.db import Database
+from bonsai_api.crud.user import create_user, oauth2_scheme
+from bonsai_api.db import Database, get_db
 from bonsai_api.models.sample import PipelineResult, SampleInDatabase
+from bonsai_api.models.user import UserInputCreate
+from bonsai_api.main import app
 from mongomock_motor import AsyncMongoMockClient
 
 from .data import *
@@ -14,12 +20,19 @@ DATABASE = "testdb"
 
 
 @pytest.fixture()
-def mongo_database():
+async def mongo_database():
     """Setup Bonsai database instance."""
     db = Database()
     db.client = AsyncMongoMockClient()
     # setup mock database
     db.setup()
+
+    # load basic fixtures
+    await db.user_collection.insert_one({
+        "username": "admin", "password": "admin",
+        "first_name": "Nollan", "last_name": "Nollsson",
+        "email": "palceholder@email.com", "roles": ["admin"],
+    })
     return db
 
 
@@ -41,3 +54,23 @@ async def sample_database(mongo_database, mtuberculosis_sample_path):
         # create sample in database
         sample = await create_sample(db=mongo_database, sample=data)
         return mongo_database
+
+
+@pytest.fixture()
+def fastapi_client(mongo_database):
+    """Setup API test client."""
+    # disable authentication for test client
+    app.dependency_overrides[oauth2_scheme] = lambda: ""
+
+    # use mocked mongo database
+    app.dependency_overrides[get_db] = lambda: mongo_database
+
+    client = TestClient(app)
+
+    return client
+
+
+def pytest_configure(config):
+    """Configure environment variables used for test."""
+    test_env = str(Path(__file__).parent / "test.env")
+    load_dotenv(test_env, override=True)

--- a/api/tests/test_cli.py
+++ b/api/tests/test_cli.py
@@ -11,7 +11,7 @@ def test_export_sample(mocker, sample_database):
     """Test exporting a sample as LIMS import file."""
 
     # patch db before running cli
-    mocker.patch("bonsai_api.cli.db", sample_database)
+    mocker.patch("bonsai_api.cli.get_db", lambda: sample_database)
 
     # run CLI command
     runner = CliRunner()

--- a/api/tests/test_cli.py
+++ b/api/tests/test_cli.py
@@ -7,7 +7,6 @@ from bonsai_api.io import TARGETED_ANTIBIOTICS
 from click.testing import CliRunner
 
 
-@pytest.mark.asyncio()
 def test_export_sample(mocker, sample_database):
     """Test exporting a sample as LIMS import file."""
 


### PR DESCRIPTION
Add foundation for testing API routes with pytest.

- API authentication is disabled when running pytest by setting the environment variable `API_AUTHENTICATION` to false
- Mongo database is being mocked by [mongomock-motor](https://github.com/michaelkryukov/mongomock_motor).
