### PR TITLE
Release v0.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ### Added
 
+### Changed
+
+### Fixed
+
+## [v0.8.0]
+
+### Added
+
 - Added select all variants button to tbprofiler and SV cards in Variant report view.
 - Added button to the groups view for adding selected samples to group.
 - Added button to the group view for removing selected samples from group.

--- a/allele_cluster_service/allele_cluster_service/__init__.py
+++ b/allele_cluster_service/allele_cluster_service/__init__.py
@@ -1,3 +1,3 @@
 """Version of allele cluster service."""
 
-__version__ = "0.2.0"
+__version__ = "0.3.0"

--- a/api/bonsai_api/__version__.py
+++ b/api/bonsai_api/__version__.py
@@ -1,3 +1,3 @@
 """API version"""
 
-VERSION = "0.7.0"
+VERSION = "0.8.0"

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -38,7 +38,7 @@ Use docker-compose to get started creating the Bonsai containers and configure t
             - bonsai-net
 
       frontend:
-         image: clinicalgenomicslund/bonsai-app:0.7.0 
+         image: clinicalgenomicslund/bonsai-app:0.8.0 
          depends_on:
             - mongodb
             - api
@@ -48,7 +48,7 @@ Use docker-compose to get started creating the Bonsai containers and configure t
             - bonsai-net
 
       api:
-         image: clinicalgenomicslund/bonsai-api:0.7.0 
+         image: clinicalgenomicslund/bonsai-api:0.8.0 
          depends_on:
             - mongodb
             - minhash_service
@@ -59,7 +59,7 @@ Use docker-compose to get started creating the Bonsai containers and configure t
             - bonsai-net
 
       minhash_service:
-         image: clinicalgenomicslund/bonsai-minhash-clustering:0.2.0 
+         image: clinicalgenomicslund/bonsai-minhash-clustering:0.3.0 
          depends_on:
             - redis
          volumes:
@@ -68,7 +68,7 @@ Use docker-compose to get started creating the Bonsai containers and configure t
             - bonsai-net
 
       allele_cluster_service:
-         image: clinicalgenomicslund/bonsai-allele-clustering:0.2.0
+         image: clinicalgenomicslund/bonsai-allele-clustering:0.3.0
          depends_on:
             - redis
          networks:

--- a/frontend/bonsai_app/__version__.py
+++ b/frontend/bonsai_app/__version__.py
@@ -1,2 +1,2 @@
 """Bonsai frontend version."""
-VERSION = "0.7.0"
+VERSION = "0.8.0"

--- a/minhash_service/minhash_service/__init__.py
+++ b/minhash_service/minhash_service/__init__.py
@@ -1,3 +1,3 @@
 """Service to perform MinHash based analysis using Sourmash."""
 
-__version__ = "0.2.0"
+__version__ = "0.3.0"


### PR DESCRIPTION
## v0.8.0

### Added

- Added select all variants button to tbprofiler and SV cards in Variant report view.
- Added button to the groups view for adding selected samples to group.
- Added button to the group view for removing selected samples from group.
- Added column with comments indicator to group and groups view.
- Added foundation for testing API routes.
- Added test for Allele cluster service.

### Changed

- Genome coverage plot to interactive and have an y-range of 0 to 100.
- Use data-tables instead of w2ui for samples tables.
- Improved error handling of allele cluster service.
- Removed swedish characters from LIMS export output.

### Fixed

- Fixed highlight of displayed sample in the dendrogram on the sample view page.
- Fixed formatting of grapetree metadata that could crash the frontend.
- Fixed crash in Allele cluster service when clustering samples with the same profile using MsTree or MsTreeV2.